### PR TITLE
draf3

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/Runner.java
+++ b/besu/src/main/java/org/hyperledger/besu/Runner.java
@@ -22,7 +22,8 @@ import org.hyperledger.besu.ethereum.p2p.network.NetworkRunner;
 import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
 import org.hyperledger.besu.ethereum.stratum.StratumServer;
 import org.hyperledger.besu.metrics.prometheus.MetricsService;
-import org.hyperledger.besu.nat.upnp.UpnpNatManager;
+import org.hyperledger.besu.nat.NatService;
+import org.hyperledger.besu.nat.core.NatManager;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -49,7 +50,7 @@ public class Runner implements AutoCloseable {
   private final CountDownLatch shutdown = new CountDownLatch(1);
 
   private final NetworkRunner networkRunner;
-  private final Optional<UpnpNatManager> natManager;
+  private final NatService natService;
   private final Optional<JsonRpcHttpService> jsonRpc;
   private final Optional<GraphQLHttpService> graphQLHttp;
   private final Optional<WebSocketService> websocketRpc;
@@ -62,7 +63,7 @@ public class Runner implements AutoCloseable {
   Runner(
       final Vertx vertx,
       final NetworkRunner networkRunner,
-      final Optional<UpnpNatManager> natManager,
+      final NatService natService,
       final Optional<JsonRpcHttpService> jsonRpc,
       final Optional<GraphQLHttpService> graphQLHttp,
       final Optional<WebSocketService> websocketRpc,
@@ -72,7 +73,7 @@ public class Runner implements AutoCloseable {
       final Path dataDir) {
     this.vertx = vertx;
     this.networkRunner = networkRunner;
-    this.natManager = natManager;
+    this.natService = natService;
     this.graphQLHttp = graphQLHttp;
     this.jsonRpc = jsonRpc;
     this.websocketRpc = websocketRpc;
@@ -85,7 +86,7 @@ public class Runner implements AutoCloseable {
   public void start() {
     try {
       LOG.info("Starting Ethereum main loop ... ");
-      natManager.ifPresent(UpnpNatManager::start);
+      natService.getNatManager().ifPresent(NatManager::start);
       networkRunner.start();
       if (networkRunner.getNetwork().isP2pEnabled()) {
         besuController.getSynchronizer().start();
@@ -125,7 +126,7 @@ public class Runner implements AutoCloseable {
     networkRunner.stop();
     waitForServiceToStop("Network", networkRunner::awaitStop);
 
-    natManager.ifPresent(UpnpNatManager::stop);
+    natService.getNatManager().ifPresent(NatManager::stop);
     besuController.close();
     vertx.close((res) -> vertxShutdownLatch.countDown());
     waitForServiceToStop("Vertx", vertxShutdownLatch::await);

--- a/besu/src/main/java/org/hyperledger/besu/Runner.java
+++ b/besu/src/main/java/org/hyperledger/besu/Runner.java
@@ -49,7 +49,7 @@ public class Runner implements AutoCloseable {
   private final CountDownLatch shutdown = new CountDownLatch(1);
 
   private final NetworkRunner networkRunner;
-  private final Optional<NatService> natService;
+  private final NatService natService;
   private final Optional<JsonRpcHttpService> jsonRpc;
   private final Optional<GraphQLHttpService> graphQLHttp;
   private final Optional<WebSocketService> websocketRpc;
@@ -62,7 +62,7 @@ public class Runner implements AutoCloseable {
   Runner(
       final Vertx vertx,
       final NetworkRunner networkRunner,
-      final Optional<NatService> natService,
+      final NatService natService,
       final Optional<JsonRpcHttpService> jsonRpc,
       final Optional<GraphQLHttpService> graphQLHttp,
       final Optional<WebSocketService> websocketRpc,
@@ -85,7 +85,7 @@ public class Runner implements AutoCloseable {
   public void start() {
     try {
       LOG.info("Starting Ethereum main loop ... ");
-      natService.ifPresent(NatService::start);
+      natService.ifNatEnvironment(NatService::start);
       networkRunner.start();
       if (networkRunner.getNetwork().isP2pEnabled()) {
         besuController.getSynchronizer().start();
@@ -125,7 +125,7 @@ public class Runner implements AutoCloseable {
     networkRunner.stop();
     waitForServiceToStop("Network", networkRunner::awaitStop);
 
-    natService.ifPresent(NatService::stop);
+    natService.ifNatEnvironment(NatService::stop);
     besuController.close();
     vertx.close((res) -> vertxShutdownLatch.countDown());
     waitForServiceToStop("Vertx", vertxShutdownLatch::await);

--- a/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
@@ -87,7 +87,7 @@ import org.hyperledger.besu.metrics.ObservableMetricsSystem;
 import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
 import org.hyperledger.besu.metrics.prometheus.MetricsService;
 import org.hyperledger.besu.nat.NatMethod;
-import org.hyperledger.besu.nat.upnp.UpnpNatManager;
+import org.hyperledger.besu.nat.NatService;
 import org.hyperledger.besu.util.NetworkUtility;
 import org.hyperledger.besu.util.bytes.BytesValue;
 
@@ -325,7 +325,7 @@ public class RunnerBuilder {
             .map(nodePerms -> PeerPermissions.combine(nodePerms, bannedNodes))
             .orElse(bannedNodes);
 
-    final Optional<UpnpNatManager> natManager = buildNatManager(natMethod);
+    final NatService natService = new NatService(natMethod);
 
     NetworkBuilder inactiveNetwork = (caps) -> new NoopP2PNetwork();
     NetworkBuilder activeNetwork =
@@ -337,7 +337,7 @@ public class RunnerBuilder {
                 .peerPermissions(peerPermissions)
                 .metricsSystem(metricsSystem)
                 .supportedCapabilities(caps)
-                .natManager(natManager)
+                .natService(natService)
                 .build();
 
     final NetworkRunner networkRunner =
@@ -419,7 +419,7 @@ public class RunnerBuilder {
                   dataDir,
                   jsonRpcConfiguration,
                   metricsSystem,
-                  natManager,
+                  natService,
                   jsonRpcMethods,
                   new HealthService(new LivenessCheck()),
                   new HealthService(new ReadinessCheck(peerNetwork, synchronizer))));
@@ -495,7 +495,7 @@ public class RunnerBuilder {
     return new Runner(
         vertx,
         networkRunner,
-        natManager,
+        natService,
         jsonRpcHttpService,
         graphQLHttpService,
         webSocketService,
@@ -527,16 +527,6 @@ public class RunnerBuilder {
       return Optional.of(nodePermissioningController);
     } else {
       return Optional.empty();
-    }
-  }
-
-  private Optional<UpnpNatManager> buildNatManager(final NatMethod natMethod) {
-    switch (natMethod) {
-      case UPNP:
-        return Optional.of(new UpnpNatManager());
-      case NONE:
-      default:
-        return Optional.ofNullable(null);
     }
   }
 

--- a/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
@@ -325,7 +325,7 @@ public class RunnerBuilder {
             .map(nodePerms -> PeerPermissions.combine(nodePerms, bannedNodes))
             .orElse(bannedNodes);
 
-    final NatService natService = new NatService(natMethod);
+    final Optional<NatService> natService = Optional.of(new NatService(natMethod));
 
     NetworkBuilder inactiveNetwork = (caps) -> new NoopP2PNetwork();
     NetworkBuilder activeNetwork =

--- a/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
@@ -325,7 +325,7 @@ public class RunnerBuilder {
             .map(nodePerms -> PeerPermissions.combine(nodePerms, bannedNodes))
             .orElse(bannedNodes);
 
-    final Optional<NatService> natService = Optional.of(new NatService(natMethod));
+    final NatService natService = new NatService(natMethod);
 
     NetworkBuilder inactiveNetwork = (caps) -> new NoopP2PNetwork();
     NetworkBuilder activeNetwork =

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpService.java
@@ -87,7 +87,7 @@ public class JsonRpcHttpService {
   private final Vertx vertx;
   private final JsonRpcConfiguration config;
   private final Map<String, JsonRpcMethod> rpcMethods;
-  private final NatService natService;
+  private final Optional<NatService> natService;
   private final Path dataDir;
   private final LabelledMetric<OperationTimer> requestTimer;
 
@@ -114,7 +114,7 @@ public class JsonRpcHttpService {
       final Path dataDir,
       final JsonRpcConfiguration config,
       final MetricsSystem metricsSystem,
-      final NatService natService,
+      final Optional<NatService> natService,
       final Map<String, JsonRpcMethod> methods,
       final HealthService livenessService,
       final HealthService readinessService) {
@@ -135,7 +135,7 @@ public class JsonRpcHttpService {
       final Path dataDir,
       final JsonRpcConfiguration config,
       final MetricsSystem metricsSystem,
-      final NatService natService,
+      final Optional<NatService> natService,
       final Map<String, JsonRpcMethod> methods,
       final Optional<AuthenticationService> authenticationService,
       final HealthService livenessService,
@@ -234,11 +234,11 @@ public class JsonRpcHttpService {
                     "JsonRPC service started and listening on {}:{}", config.getHost(), actualPort);
                 config.setPort(actualPort);
 
-                if (natService.isNATEnvironment()) {
-                  // Request that a NAT port forward for our server port
-                  final NatMethod natMethod = natService.getNatMethod();
-                  if (natMethod.equals(NatMethod.UPNP)) {
-                    natService
+                if (natService.isPresent()) {
+                  final NatService service = natService.get();
+                  // request that a NAT port forward for our server port (if UPNP Nat Environment)
+                  if (service.isNatEnvironment() && service.getNatMethod().equals(NatMethod.UPNP)) {
+                    service
                         .getNatManager()
                         .ifPresent(
                             natSystem -> {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/AbstractJsonRpcHttpServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/AbstractJsonRpcHttpServiceTest.java
@@ -44,8 +44,6 @@ import org.hyperledger.besu.ethereum.p2p.network.P2PNetwork;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
-import org.hyperledger.besu.nat.NatMethod;
-import org.hyperledger.besu.nat.NatService;
 import org.hyperledger.besu.testutil.BlockTestUtil.ChainResources;
 
 import java.math.BigInteger;
@@ -179,7 +177,7 @@ public abstract class AbstractJsonRpcHttpServiceTest {
             folder.newFolder().toPath(),
             config,
             new NoOpMetricsSystem(),
-            new NatService(NatMethod.NONE),
+            Optional.empty(),
             methods,
             HealthService.ALWAYS_HEALTHY,
             HealthService.ALWAYS_HEALTHY);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/AbstractJsonRpcHttpServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/AbstractJsonRpcHttpServiceTest.java
@@ -44,6 +44,8 @@ import org.hyperledger.besu.ethereum.p2p.network.P2PNetwork;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
+import org.hyperledger.besu.nat.NatMethod;
+import org.hyperledger.besu.nat.NatService;
 import org.hyperledger.besu.testutil.BlockTestUtil.ChainResources;
 
 import java.math.BigInteger;
@@ -177,7 +179,7 @@ public abstract class AbstractJsonRpcHttpServiceTest {
             folder.newFolder().toPath(),
             config,
             new NoOpMetricsSystem(),
-            Optional.empty(),
+            new NatService(NatMethod.NONE),
             methods,
             HealthService.ALWAYS_HEALTHY,
             HealthService.ALWAYS_HEALTHY);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceCorsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceCorsTest.java
@@ -18,9 +18,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.health.HealthService;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+import org.hyperledger.besu.nat.NatMethod;
+import org.hyperledger.besu.nat.NatService;
 
 import java.util.HashMap;
-import java.util.Optional;
 
 import com.google.common.collect.Lists;
 import io.vertx.core.Vertx;
@@ -196,7 +197,7 @@ public class JsonRpcHttpServiceCorsTest {
             folder.newFolder().toPath(),
             config,
             new NoOpMetricsSystem(),
-            Optional.empty(),
+            new NatService(NatMethod.NONE),
             new HashMap<>(),
             HealthService.ALWAYS_HEALTHY,
             HealthService.ALWAYS_HEALTHY);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceCorsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceCorsTest.java
@@ -18,10 +18,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.health.HealthService;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
-import org.hyperledger.besu.nat.NatMethod;
-import org.hyperledger.besu.nat.NatService;
 
 import java.util.HashMap;
+import java.util.Optional;
 
 import com.google.common.collect.Lists;
 import io.vertx.core.Vertx;
@@ -197,7 +196,7 @@ public class JsonRpcHttpServiceCorsTest {
             folder.newFolder().toPath(),
             config,
             new NoOpMetricsSystem(),
-            new NatService(NatMethod.NONE),
+            Optional.empty(),
             new HashMap<>(),
             HealthService.ALWAYS_HEALTHY,
             HealthService.ALWAYS_HEALTHY);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceHostWhitelistTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceHostWhitelistTest.java
@@ -37,8 +37,6 @@ import org.hyperledger.besu.ethereum.permissioning.AccountLocalConfigPermissioni
 import org.hyperledger.besu.ethereum.permissioning.NodeLocalConfigPermissioningController;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
-import org.hyperledger.besu.nat.NatMethod;
-import org.hyperledger.besu.nat.NatService;
 
 import java.io.IOException;
 import java.math.BigInteger;
@@ -128,7 +126,7 @@ public class JsonRpcHttpServiceHostWhitelistTest {
         folder.newFolder().toPath(),
         jsonRpcConfig,
         new NoOpMetricsSystem(),
-        new NatService(NatMethod.NONE),
+        Optional.empty(),
         rpcMethods,
         HealthService.ALWAYS_HEALTHY,
         HealthService.ALWAYS_HEALTHY);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceHostWhitelistTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceHostWhitelistTest.java
@@ -37,6 +37,8 @@ import org.hyperledger.besu.ethereum.permissioning.AccountLocalConfigPermissioni
 import org.hyperledger.besu.ethereum.permissioning.NodeLocalConfigPermissioningController;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
+import org.hyperledger.besu.nat.NatMethod;
+import org.hyperledger.besu.nat.NatService;
 
 import java.io.IOException;
 import java.math.BigInteger;
@@ -126,7 +128,7 @@ public class JsonRpcHttpServiceHostWhitelistTest {
         folder.newFolder().toPath(),
         jsonRpcConfig,
         new NoOpMetricsSystem(),
-        Optional.empty(),
+        new NatService(NatMethod.NONE),
         rpcMethods,
         HealthService.ALWAYS_HEALTHY,
         HealthService.ALWAYS_HEALTHY);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceLoginTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceLoginTest.java
@@ -41,6 +41,8 @@ import org.hyperledger.besu.ethereum.p2p.network.P2PNetwork;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
+import org.hyperledger.besu.nat.NatMethod;
+import org.hyperledger.besu.nat.NatService;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -168,7 +170,7 @@ public class JsonRpcHttpServiceLoginTest {
         folder.newFolder().toPath(),
         config,
         new NoOpMetricsSystem(),
-        Optional.empty(),
+        new NatService(NatMethod.NONE),
         rpcMethods,
         HealthService.ALWAYS_HEALTHY,
         HealthService.ALWAYS_HEALTHY);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceLoginTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceLoginTest.java
@@ -41,8 +41,6 @@ import org.hyperledger.besu.ethereum.p2p.network.P2PNetwork;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
-import org.hyperledger.besu.nat.NatMethod;
-import org.hyperledger.besu.nat.NatService;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -170,7 +168,7 @@ public class JsonRpcHttpServiceLoginTest {
         folder.newFolder().toPath(),
         config,
         new NoOpMetricsSystem(),
-        new NatService(NatMethod.NONE),
+        Optional.empty(),
         rpcMethods,
         HealthService.ALWAYS_HEALTHY,
         HealthService.ALWAYS_HEALTHY);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceRpcApisTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceRpcApisTest.java
@@ -44,6 +44,8 @@ import org.hyperledger.besu.ethereum.permissioning.AccountLocalConfigPermissioni
 import org.hyperledger.besu.ethereum.permissioning.NodeLocalConfigPermissioningController;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
+import org.hyperledger.besu.nat.NatMethod;
+import org.hyperledger.besu.nat.NatService;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -213,7 +215,7 @@ public class JsonRpcHttpServiceRpcApisTest {
             folder.newFolder().toPath(),
             config,
             new NoOpMetricsSystem(),
-            Optional.empty(),
+            new NatService(NatMethod.NONE),
             rpcMethods,
             HealthService.ALWAYS_HEALTHY,
             HealthService.ALWAYS_HEALTHY);
@@ -303,7 +305,7 @@ public class JsonRpcHttpServiceRpcApisTest {
             folder.newFolder().toPath(),
             jsonRpcConfiguration,
             new NoOpMetricsSystem(),
-            Optional.empty(),
+            new NatService(NatMethod.NONE),
             rpcMethods,
             HealthService.ALWAYS_HEALTHY,
             HealthService.ALWAYS_HEALTHY);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceRpcApisTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceRpcApisTest.java
@@ -44,8 +44,6 @@ import org.hyperledger.besu.ethereum.permissioning.AccountLocalConfigPermissioni
 import org.hyperledger.besu.ethereum.permissioning.NodeLocalConfigPermissioningController;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
-import org.hyperledger.besu.nat.NatMethod;
-import org.hyperledger.besu.nat.NatService;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -215,7 +213,7 @@ public class JsonRpcHttpServiceRpcApisTest {
             folder.newFolder().toPath(),
             config,
             new NoOpMetricsSystem(),
-            new NatService(NatMethod.NONE),
+            Optional.empty(),
             rpcMethods,
             HealthService.ALWAYS_HEALTHY,
             HealthService.ALWAYS_HEALTHY);
@@ -305,7 +303,7 @@ public class JsonRpcHttpServiceRpcApisTest {
             folder.newFolder().toPath(),
             jsonRpcConfiguration,
             new NoOpMetricsSystem(),
-            new NatService(NatMethod.NONE),
+            Optional.empty(),
             rpcMethods,
             HealthService.ALWAYS_HEALTHY,
             HealthService.ALWAYS_HEALTHY);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTest.java
@@ -55,8 +55,6 @@ import org.hyperledger.besu.ethereum.permissioning.AccountLocalConfigPermissioni
 import org.hyperledger.besu.ethereum.permissioning.NodeLocalConfigPermissioningController;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
-import org.hyperledger.besu.nat.NatMethod;
-import org.hyperledger.besu.nat.NatService;
 import org.hyperledger.besu.plugin.data.SyncStatus;
 import org.hyperledger.besu.util.bytes.BytesValue;
 import org.hyperledger.besu.util.bytes.BytesValues;
@@ -161,7 +159,7 @@ public class JsonRpcHttpServiceTest {
         folder.newFolder().toPath(),
         config,
         new NoOpMetricsSystem(),
-        new NatService(NatMethod.NONE),
+        Optional.empty(),
         rpcMethods,
         HealthService.ALWAYS_HEALTHY,
         HealthService.ALWAYS_HEALTHY);
@@ -173,7 +171,7 @@ public class JsonRpcHttpServiceTest {
         folder.newFolder().toPath(),
         createJsonRpcConfig(),
         new NoOpMetricsSystem(),
-        new NatService(NatMethod.NONE),
+        Optional.empty(),
         rpcMethods,
         HealthService.ALWAYS_HEALTHY,
         HealthService.ALWAYS_HEALTHY);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTest.java
@@ -55,6 +55,8 @@ import org.hyperledger.besu.ethereum.permissioning.AccountLocalConfigPermissioni
 import org.hyperledger.besu.ethereum.permissioning.NodeLocalConfigPermissioningController;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
+import org.hyperledger.besu.nat.NatMethod;
+import org.hyperledger.besu.nat.NatService;
 import org.hyperledger.besu.plugin.data.SyncStatus;
 import org.hyperledger.besu.util.bytes.BytesValue;
 import org.hyperledger.besu.util.bytes.BytesValues;
@@ -159,7 +161,7 @@ public class JsonRpcHttpServiceTest {
         folder.newFolder().toPath(),
         config,
         new NoOpMetricsSystem(),
-        Optional.empty(),
+        new NatService(NatMethod.NONE),
         rpcMethods,
         HealthService.ALWAYS_HEALTHY,
         HealthService.ALWAYS_HEALTHY);
@@ -171,7 +173,7 @@ public class JsonRpcHttpServiceTest {
         folder.newFolder().toPath(),
         createJsonRpcConfig(),
         new NoOpMetricsSystem(),
-        Optional.empty(),
+        new NatService(NatMethod.NONE),
         rpcMethods,
         HealthService.ALWAYS_HEALTHY,
         HealthService.ALWAYS_HEALTHY);

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgent.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgent.java
@@ -29,7 +29,7 @@ import org.hyperledger.besu.ethereum.p2p.discovery.internal.TimerUtil;
 import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
 import org.hyperledger.besu.ethereum.p2p.peers.PeerId;
 import org.hyperledger.besu.ethereum.p2p.permissions.PeerPermissions;
-import org.hyperledger.besu.nat.upnp.UpnpNatManager;
+import org.hyperledger.besu.nat.NatService;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.util.NetworkUtility;
 import org.hyperledger.besu.util.Subscribers;
@@ -42,7 +42,6 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -65,7 +64,7 @@ public abstract class PeerDiscoveryAgent {
   protected final List<DiscoveryPeer> bootstrapPeers;
   private final List<PeerRequirement> peerRequirements = new CopyOnWriteArrayList<>();
   private final PeerPermissions peerPermissions;
-  private final Optional<UpnpNatManager> natManager;
+  private final NatService natService;
   private final MetricsSystem metricsSystem;
   /* The peer controller, which takes care of the state machine of peers. */
   protected Optional<PeerDiscoveryController> controller = Optional.empty();
@@ -88,7 +87,7 @@ public abstract class PeerDiscoveryAgent {
       final SECP256K1.KeyPair keyPair,
       final DiscoveryConfiguration config,
       final PeerPermissions peerPermissions,
-      final Optional<UpnpNatManager> natManager,
+      final NatService natService,
       final MetricsSystem metricsSystem) {
     this.metricsSystem = metricsSystem;
     checkArgument(keyPair != null, "keypair cannot be null");
@@ -97,7 +96,7 @@ public abstract class PeerDiscoveryAgent {
     validateConfiguration(config);
 
     this.peerPermissions = peerPermissions;
-    this.natManager = natManager;
+    this.natService = natService;
     this.bootstrapPeers =
         config.getBootnodes().stream().map(DiscoveryPeer::fromEnode).collect(Collectors.toList());
 
@@ -125,24 +124,8 @@ public abstract class PeerDiscoveryAgent {
       LOG.info("Starting peer discovery agent on host={}, port={}", host, port);
 
       // override advertised host if we detect an external IP address via NAT manager
-      String externalIpAddress = null;
-      if (natManager.isPresent()) {
-        try {
-          final int timeoutSeconds = 60;
-          LOG.info("Waiting for up to {} seconds to detect external IP address...", timeoutSeconds);
-          externalIpAddress =
-              natManager.get().queryExternalIPAddress().get(timeoutSeconds, TimeUnit.SECONDS);
-
-        } catch (Exception e) {
-          LOG.warn(
-              "Caught exception while trying to query NAT external IP address (ignoring): {}", e);
-        }
-      }
-
       final String advertisedAddress =
-          (null != externalIpAddress && !externalIpAddress.equals(""))
-              ? externalIpAddress
-              : config.getAdvertisedHost();
+          natService.queryExternalIPAddress().orElseGet(config::getAdvertisedHost);
 
       return listenForConnections()
           .thenApply(

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgent.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgent.java
@@ -64,7 +64,7 @@ public abstract class PeerDiscoveryAgent {
   protected final List<DiscoveryPeer> bootstrapPeers;
   private final List<PeerRequirement> peerRequirements = new CopyOnWriteArrayList<>();
   private final PeerPermissions peerPermissions;
-  private final NatService natService;
+  private final Optional<NatService> natService;
   private final MetricsSystem metricsSystem;
   /* The peer controller, which takes care of the state machine of peers. */
   protected Optional<PeerDiscoveryController> controller = Optional.empty();
@@ -87,7 +87,7 @@ public abstract class PeerDiscoveryAgent {
       final SECP256K1.KeyPair keyPair,
       final DiscoveryConfiguration config,
       final PeerPermissions peerPermissions,
-      final NatService natService,
+      final Optional<NatService> natService,
       final MetricsSystem metricsSystem) {
     this.metricsSystem = metricsSystem;
     checkArgument(keyPair != null, "keypair cannot be null");
@@ -124,8 +124,13 @@ public abstract class PeerDiscoveryAgent {
       LOG.info("Starting peer discovery agent on host={}, port={}", host, port);
 
       // override advertised host if we detect an external IP address via NAT manager
-      final String advertisedAddress =
-          natService.queryExternalIPAddress().orElseGet(config::getAdvertisedHost);
+      final String advertisedAddress;
+      if (natService.isPresent()) {
+        advertisedAddress =
+            natService.get().queryExternalIPAddress().orElseGet(config::getAdvertisedHost);
+      } else {
+        advertisedAddress = config.getAdvertisedHost();
+      }
 
       return listenForConnections()
           .thenApply(

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgent.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgent.java
@@ -64,7 +64,7 @@ public abstract class PeerDiscoveryAgent {
   protected final List<DiscoveryPeer> bootstrapPeers;
   private final List<PeerRequirement> peerRequirements = new CopyOnWriteArrayList<>();
   private final PeerPermissions peerPermissions;
-  private final Optional<NatService> natService;
+  private final NatService natService;
   private final MetricsSystem metricsSystem;
   /* The peer controller, which takes care of the state machine of peers. */
   protected Optional<PeerDiscoveryController> controller = Optional.empty();
@@ -87,7 +87,7 @@ public abstract class PeerDiscoveryAgent {
       final SECP256K1.KeyPair keyPair,
       final DiscoveryConfiguration config,
       final PeerPermissions peerPermissions,
-      final Optional<NatService> natService,
+      final NatService natService,
       final MetricsSystem metricsSystem) {
     this.metricsSystem = metricsSystem;
     checkArgument(keyPair != null, "keypair cannot be null");
@@ -124,13 +124,8 @@ public abstract class PeerDiscoveryAgent {
       LOG.info("Starting peer discovery agent on host={}, port={}", host, port);
 
       // override advertised host if we detect an external IP address via NAT manager
-      final String advertisedAddress;
-      if (natService.isPresent()) {
-        advertisedAddress =
-            natService.get().queryExternalIPAddress().orElseGet(config::getAdvertisedHost);
-      } else {
-        advertisedAddress = config.getAdvertisedHost();
-      }
+      final String advertisedAddress =
+          natService.queryExternalIPAddress().orElse(config.getAdvertisedHost());
 
       return listenForConnections()
           .thenApply(

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/VertxPeerDiscoveryAgent.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/VertxPeerDiscoveryAgent.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.net.BindException;
 import java.net.InetSocketAddress;
 import java.net.SocketException;
+import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.IntSupplier;
@@ -61,7 +62,7 @@ public class VertxPeerDiscoveryAgent extends PeerDiscoveryAgent {
       final KeyPair keyPair,
       final DiscoveryConfiguration config,
       final PeerPermissions peerPermissions,
-      final NatService natService,
+      final Optional<NatService> natService,
       final MetricsSystem metricsSystem) {
     super(keyPair, config, peerPermissions, natService, metricsSystem);
     checkArgument(vertx != null, "vertx instance cannot be null");

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/VertxPeerDiscoveryAgent.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/VertxPeerDiscoveryAgent.java
@@ -25,7 +25,7 @@ import org.hyperledger.besu.ethereum.p2p.discovery.internal.TimerUtil;
 import org.hyperledger.besu.ethereum.p2p.discovery.internal.VertxTimerUtil;
 import org.hyperledger.besu.ethereum.p2p.permissions.PeerPermissions;
 import org.hyperledger.besu.metrics.BesuMetricCategory;
-import org.hyperledger.besu.nat.upnp.UpnpNatManager;
+import org.hyperledger.besu.nat.NatService;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.util.NetworkUtility;
 
@@ -33,7 +33,6 @@ import java.io.IOException;
 import java.net.BindException;
 import java.net.InetSocketAddress;
 import java.net.SocketException;
-import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.IntSupplier;
@@ -62,9 +61,9 @@ public class VertxPeerDiscoveryAgent extends PeerDiscoveryAgent {
       final KeyPair keyPair,
       final DiscoveryConfiguration config,
       final PeerPermissions peerPermissions,
-      final Optional<UpnpNatManager> natManager,
+      final NatService natService,
       final MetricsSystem metricsSystem) {
-    super(keyPair, config, peerPermissions, natManager, metricsSystem);
+    super(keyPair, config, peerPermissions, natService, metricsSystem);
     checkArgument(vertx != null, "vertx instance cannot be null");
     this.vertx = vertx;
 

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/VertxPeerDiscoveryAgent.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/VertxPeerDiscoveryAgent.java
@@ -33,7 +33,6 @@ import java.io.IOException;
 import java.net.BindException;
 import java.net.InetSocketAddress;
 import java.net.SocketException;
-import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.IntSupplier;
@@ -62,7 +61,7 @@ public class VertxPeerDiscoveryAgent extends PeerDiscoveryAgent {
       final KeyPair keyPair,
       final DiscoveryConfiguration config,
       final PeerPermissions peerPermissions,
-      final Optional<NatService> natService,
+      final NatService natService,
       final MetricsSystem metricsSystem) {
     super(keyPair, config, peerPermissions, natService, metricsSystem);
     checkArgument(vertx != null, "vertx instance cannot be null");

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetwork.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetwork.java
@@ -128,7 +128,7 @@ public class DefaultP2PNetwork implements P2PNetwork {
   private final PeerPermissions peerPermissions;
   private final MaintainedPeers maintainedPeers;
 
-  private NatService natService;
+  private Optional<NatService> natService;
 
   private OptionalLong peerBondedObserverId = OptionalLong.empty();
 
@@ -161,7 +161,7 @@ public class DefaultP2PNetwork implements P2PNetwork {
       final SECP256K1.KeyPair keyPair,
       final NetworkingConfiguration config,
       final PeerPermissions peerPermissions,
-      final NatService natService,
+      final Optional<NatService> natService,
       final MaintainedPeers maintainedPeers,
       final PeerReputationManager reputationManager) {
 
@@ -204,9 +204,12 @@ public class DefaultP2PNetwork implements P2PNetwork {
                     : configuredDiscoveryPort)
             .join();
 
-    if (natService.isNATEnvironment()) {
-      this.configureNatEnvironment(listeningPort, discoveryPort);
-    }
+    natService.ifPresent(
+        service -> {
+          if (service.isNatEnvironment()) {
+            this.configureNatEnvironment(service, listeningPort, discoveryPort);
+          }
+        });
 
     setLocalNode(address, listeningPort, discoveryPort);
 
@@ -362,7 +365,12 @@ public class DefaultP2PNetwork implements P2PNetwork {
       return;
     }
 
-    final String advertisedAddress = natService.queryExternalIPAddress().orElse(address);
+    final String advertisedAddress;
+    if (natService.isPresent()) {
+      advertisedAddress = natService.get().queryExternalIPAddress().orElse(address);
+    } else {
+      advertisedAddress = address;
+    }
 
     final EnodeURL localEnode =
         EnodeURL.builder()
@@ -376,7 +384,8 @@ public class DefaultP2PNetwork implements P2PNetwork {
     localNode.setEnode(localEnode);
   }
 
-  private void configureNatEnvironment(final int listeningPort, final int discoveryPort) {
+  private void configureNatEnvironment(
+      final NatService natService, final int listeningPort, final int discoveryPort) {
 
     try {
       final NatManager natManager = natService.getNatManager().orElseThrow();
@@ -409,7 +418,7 @@ public class DefaultP2PNetwork implements P2PNetwork {
     private MaintainedPeers maintainedPeers = new MaintainedPeers();
     private PeerPermissions peerPermissions = PeerPermissions.noop();
 
-    private NatService natService = new NatService(NatMethod.NONE);
+    private Optional<NatService> natService = Optional.empty();
     private MetricsSystem metricsSystem;
 
     public P2PNetwork build() {
@@ -524,6 +533,12 @@ public class DefaultP2PNetwork implements P2PNetwork {
     }
 
     public Builder natService(final NatService natService) {
+      checkNotNull(natService);
+      this.natService = Optional.ofNullable(natService);
+      return this;
+    }
+
+    public Builder natService(final Optional<NatService> natService) {
       checkNotNull(natService);
       this.natService = natService;
       return this;

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/MockPeerDiscoveryAgent.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/MockPeerDiscoveryAgent.java
@@ -21,8 +21,6 @@ import org.hyperledger.besu.ethereum.p2p.discovery.PeerDiscoveryAgent;
 import org.hyperledger.besu.ethereum.p2p.discovery.internal.PeerDiscoveryController.AsyncExecutor;
 import org.hyperledger.besu.ethereum.p2p.permissions.PeerPermissions;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
-import org.hyperledger.besu.nat.NatMethod;
-import org.hyperledger.besu.nat.NatService;
 import org.hyperledger.besu.util.bytes.BytesValue;
 
 import java.net.InetSocketAddress;
@@ -31,6 +29,7 @@ import java.util.Arrays;
 import java.util.Deque;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 public class MockPeerDiscoveryAgent extends PeerDiscoveryAgent {
@@ -44,8 +43,7 @@ public class MockPeerDiscoveryAgent extends PeerDiscoveryAgent {
       final DiscoveryConfiguration config,
       final PeerPermissions peerPermissions,
       final Map<BytesValue, MockPeerDiscoveryAgent> agentNetwork) {
-    super(
-        keyPair, config, peerPermissions, new NatService(NatMethod.NONE), new NoOpMetricsSystem());
+    super(keyPair, config, peerPermissions, Optional.empty(), new NoOpMetricsSystem());
     this.agentNetwork = agentNetwork;
   }
 

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/MockPeerDiscoveryAgent.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/MockPeerDiscoveryAgent.java
@@ -21,6 +21,8 @@ import org.hyperledger.besu.ethereum.p2p.discovery.PeerDiscoveryAgent;
 import org.hyperledger.besu.ethereum.p2p.discovery.internal.PeerDiscoveryController.AsyncExecutor;
 import org.hyperledger.besu.ethereum.p2p.permissions.PeerPermissions;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+import org.hyperledger.besu.nat.NatMethod;
+import org.hyperledger.besu.nat.NatService;
 import org.hyperledger.besu.util.bytes.BytesValue;
 
 import java.net.InetSocketAddress;
@@ -29,7 +31,6 @@ import java.util.Arrays;
 import java.util.Deque;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 public class MockPeerDiscoveryAgent extends PeerDiscoveryAgent {
@@ -43,7 +44,8 @@ public class MockPeerDiscoveryAgent extends PeerDiscoveryAgent {
       final DiscoveryConfiguration config,
       final PeerPermissions peerPermissions,
       final Map<BytesValue, MockPeerDiscoveryAgent> agentNetwork) {
-    super(keyPair, config, peerPermissions, Optional.empty(), new NoOpMetricsSystem());
+    super(
+        keyPair, config, peerPermissions, new NatService(NatMethod.NONE), new NoOpMetricsSystem());
     this.agentNetwork = agentNetwork;
   }
 

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetworkTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetworkTest.java
@@ -19,6 +19,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -43,8 +44,10 @@ import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.MockSubProtocol;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.messages.DisconnectMessage.DisconnectReason;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+import org.hyperledger.besu.nat.NatMethod;
+import org.hyperledger.besu.nat.NatService;
+import org.hyperledger.besu.nat.core.domain.NetworkProtocol;
 import org.hyperledger.besu.nat.upnp.UpnpNatManager;
-import org.hyperledger.besu.nat.upnp.UpnpNatManager.Protocol;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -69,7 +72,7 @@ public final class DefaultP2PNetworkTest {
   final MaintainedPeers maintainedPeers = new MaintainedPeers();
   @Mock PeerDiscoveryAgent discoveryAgent;
   @Mock RlpxAgent rlpxAgent;
-  @Mock UpnpNatManager natManager;
+  @Mock NatService natService;
 
   private final ArgumentCaptor<PeerBondedObserver> discoverySubscriberCaptor =
       ArgumentCaptor.forClass(PeerBondedObserver.class);
@@ -217,15 +220,22 @@ public final class DefaultP2PNetworkTest {
     config.getRlpx().setBindPort(30303);
     config.getDiscovery().setBindPort(30301);
 
-    when(natManager.queryExternalIPAddress())
-        .thenReturn(CompletableFuture.completedFuture(externalIp));
-    final P2PNetwork network = builder().natManager(natManager).build();
+    UpnpNatManager upnpNatManager = mock(UpnpNatManager.class);
+
+    when(natService.getNatManager()).thenReturn(Optional.of(upnpNatManager));
+
+    when(natService.isNATEnvironment()).thenReturn(true);
+    when(natService.getNatMethod()).thenReturn(NatMethod.UPNP);
+
+    when(natService.queryExternalIPAddress()).thenReturn(Optional.of(externalIp));
+    final P2PNetwork network = builder().natService(natService).build();
 
     network.start();
-    verify(natManager)
-        .requestPortForward(eq(config.getRlpx().getBindPort()), eq(Protocol.TCP), any());
-    verify(natManager)
-        .requestPortForward(eq(config.getDiscovery().getBindPort()), eq(Protocol.UDP), any());
+    verify(upnpNatManager)
+        .requestPortForward(eq(config.getRlpx().getBindPort()), eq(NetworkProtocol.TCP), any());
+    verify(upnpNatManager)
+        .requestPortForward(
+            eq(config.getDiscovery().getBindPort()), eq(NetworkProtocol.UDP), any());
 
     Assertions.assertThat(network.getLocalEnode().get().getIpAsString()).isEqualTo(externalIp);
   }

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetworkTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetworkTest.java
@@ -224,7 +224,7 @@ public final class DefaultP2PNetworkTest {
 
     when(natService.getNatManager()).thenReturn(Optional.of(upnpNatManager));
 
-    when(natService.isNATEnvironment()).thenReturn(true);
+    when(natService.isNatEnvironment()).thenReturn(true);
     when(natService.getNatMethod()).thenReturn(NatMethod.UPNP);
 
     when(natService.queryExternalIPAddress()).thenReturn(Optional.of(externalIp));

--- a/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/RetestethService.java
+++ b/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/RetestethService.java
@@ -36,10 +36,11 @@ import org.hyperledger.besu.ethereum.retesteth.methods.TestModifyTimestamp;
 import org.hyperledger.besu.ethereum.retesteth.methods.TestRewindToBlock;
 import org.hyperledger.besu.ethereum.retesteth.methods.TestSetChainParams;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+import org.hyperledger.besu.nat.NatMethod;
+import org.hyperledger.besu.nat.NatService;
 
 import java.util.Arrays;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import io.vertx.core.Vertx;
@@ -87,7 +88,7 @@ public class RetestethService {
             retestethConfiguration.getDataPath(),
             jsonRpcConfiguration,
             new NoOpMetricsSystem(),
-            Optional.empty(),
+            new NatService(NatMethod.NONE),
             jsonRpcMethods,
             new HealthService(new LivenessCheck()),
             HealthService.ALWAYS_HEALTHY);

--- a/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/RetestethService.java
+++ b/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/RetestethService.java
@@ -36,11 +36,10 @@ import org.hyperledger.besu.ethereum.retesteth.methods.TestModifyTimestamp;
 import org.hyperledger.besu.ethereum.retesteth.methods.TestRewindToBlock;
 import org.hyperledger.besu.ethereum.retesteth.methods.TestSetChainParams;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
-import org.hyperledger.besu.nat.NatMethod;
-import org.hyperledger.besu.nat.NatService;
 
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import io.vertx.core.Vertx;
@@ -88,7 +87,7 @@ public class RetestethService {
             retestethConfiguration.getDataPath(),
             jsonRpcConfiguration,
             new NoOpMetricsSystem(),
-            new NatService(NatMethod.NONE),
+            Optional.empty(),
             jsonRpcMethods,
             new HealthService(new LivenessCheck()),
             HealthService.ALWAYS_HEALTHY);

--- a/nat/src/main/java/org/hyperledger/besu/nat/NatService.java
+++ b/nat/src/main/java/org/hyperledger/besu/nat/NatService.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.nat;
+
+import org.hyperledger.besu.nat.core.NatManager;
+import org.hyperledger.besu.nat.core.domain.NatPortMapping;
+import org.hyperledger.besu.nat.core.domain.NatServiceType;
+import org.hyperledger.besu.nat.core.domain.NetworkProtocol;
+import org.hyperledger.besu.nat.upnp.UpnpNatManager;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/** Utility class to help interacting with various {@link NatManager}. */
+public class NatService {
+
+  protected static final Logger LOG = LogManager.getLogger();
+
+  private final NatMethod currentNatMethod;
+  private Optional<NatManager> currentNatManager;
+
+  public NatService(final NatMethod natMethod) {
+    this.currentNatMethod = natMethod;
+    this.currentNatManager = buildNatSystem(currentNatMethod);
+  }
+
+  /**
+   * Returns whether or not the Besu node is running under a NAT environment.
+   *
+   * @return true if Besu node is running under NAT environment, false otherwise.
+   */
+  public boolean isNATEnvironment() {
+    return currentNatMethod != NatMethod.NONE;
+  }
+
+  /**
+   * Returns the NAT method.
+   *
+   * @return an {@link Optional} wrapping the {@link NatMethod} or empty if not found.
+   */
+  public NatMethod getNatMethod() {
+    return currentNatMethod;
+  }
+
+  /**
+   * Returns the NAT system associated to the current NAT method.
+   *
+   * @return an {@link Optional} wrapping the {@link NatManager} or empty if not found.
+   */
+  public Optional<NatManager> getNatManager() {
+    return currentNatManager;
+  }
+
+  /**
+   * Returns a {@link Optional} wrapping the advertised IP address.
+   *
+   * @return The advertised IP address wrapped in a {@link Optional}. Empty if
+   *     `isNatExternalIpUsageEnabled` is false
+   */
+  public Optional<String> queryExternalIPAddress() {
+    if (isNATEnvironment()) {
+      try {
+        final NatManager natSystem = getNatManager().get();
+        LOG.info(
+            "Waiting for up to {} seconds to detect external IP address...",
+            NatManager.TIMEOUT_SECONDS);
+        return Optional.of(
+            natSystem.queryExternalIPAddress().get(NatManager.TIMEOUT_SECONDS, TimeUnit.SECONDS));
+
+      } catch (Exception e) {
+        LOG.warn(
+            "Caught exception while trying to query NAT external IP address (ignoring): {}", e);
+      }
+    }
+    return Optional.empty();
+  }
+
+  /**
+   * Returns a {@link Optional} wrapping the local IP address.
+   *
+   * @return The local IP address wrapped in a {@link Optional}.
+   */
+  public Optional<String> queryLocalIPAddress() throws RuntimeException {
+    if (isNATEnvironment()) {
+      try {
+        final NatManager natSystem = getNatManager().orElseThrow();
+        LOG.info(
+            "Waiting for up to {} seconds to detect external IP address...",
+            NatManager.TIMEOUT_SECONDS);
+        return Optional.of(
+            natSystem.queryLocalIPAddress().get(NatManager.TIMEOUT_SECONDS, TimeUnit.SECONDS));
+      } catch (Exception e) {
+        LOG.warn("Caught exception while trying to query local IP address (ignoring): {}", e);
+      }
+    }
+    return Optional.empty();
+  }
+
+  /**
+   * Returns the port mapping associated to the passed service type.
+   *
+   * @param serviceType The service type {@link NatServiceType}.
+   * @param networkProtocol The network protocol {@link NetworkProtocol}.
+   * @return The port mapping {@link NatPortMapping}
+   */
+  public Optional<NatPortMapping> getPortMapping(
+      final NatServiceType serviceType, final NetworkProtocol networkProtocol) {
+    if (isNATEnvironment()) {
+      try {
+        final NatManager natSystem = getNatManager().orElseThrow();
+        return Optional.of(natSystem.getPortMapping(serviceType, networkProtocol));
+      } catch (Exception e) {
+        LOG.warn("Caught exception while trying to query port mapping (ignoring): {}", e);
+      }
+    }
+    return Optional.empty();
+  }
+
+  @VisibleForTesting
+  void setNatSystem(final NatManager natManager) {
+    this.currentNatManager = Optional.of(natManager);
+  }
+
+  /** Initialize the current NatMethod. */
+  private Optional<NatManager> buildNatSystem(final NatMethod givenNatMethod) {
+    switch (givenNatMethod) {
+      case UPNP:
+        return Optional.of(new UpnpNatManager());
+      case NONE:
+      default:
+        return Optional.empty();
+    }
+  }
+}

--- a/nat/src/main/java/org/hyperledger/besu/nat/NatService.java
+++ b/nat/src/main/java/org/hyperledger/besu/nat/NatService.java
@@ -45,7 +45,7 @@ public class NatService {
    *
    * @return true if Besu node is running under NAT environment, false otherwise.
    */
-  public boolean isNATEnvironment() {
+  public boolean isNatEnvironment() {
     return currentNatMethod != NatMethod.NONE;
   }
 
@@ -67,6 +67,28 @@ public class NatService {
     return currentNatManager;
   }
 
+  /** Starts the system or service. */
+  public void start() {
+    if (isNatEnvironment()) {
+      try {
+        getNatManager().orElseThrow().start();
+      } catch (Exception e) {
+        LOG.warn("Caught exception while trying to start the system or service", e);
+      }
+    }
+  }
+
+  /** Stops the system or service. */
+  public void stop() {
+    if (isNatEnvironment()) {
+      try {
+        getNatManager().orElseThrow().stop();
+      } catch (Exception e) {
+        LOG.warn("Caught exception while trying to stop the system or service", e);
+      }
+    }
+  }
+
   /**
    * Returns a {@link Optional} wrapping the advertised IP address.
    *
@@ -74,9 +96,9 @@ public class NatService {
    *     `isNatExternalIpUsageEnabled` is false
    */
   public Optional<String> queryExternalIPAddress() {
-    if (isNATEnvironment()) {
+    if (isNatEnvironment()) {
       try {
-        final NatManager natSystem = getNatManager().get();
+        final NatManager natSystem = getNatManager().orElseThrow();
         LOG.info(
             "Waiting for up to {} seconds to detect external IP address...",
             NatManager.TIMEOUT_SECONDS);
@@ -97,7 +119,7 @@ public class NatService {
    * @return The local IP address wrapped in a {@link Optional}.
    */
   public Optional<String> queryLocalIPAddress() throws RuntimeException {
-    if (isNATEnvironment()) {
+    if (isNatEnvironment()) {
       try {
         final NatManager natSystem = getNatManager().orElseThrow();
         LOG.info(
@@ -121,7 +143,7 @@ public class NatService {
    */
   public Optional<NatPortMapping> getPortMapping(
       final NatServiceType serviceType, final NetworkProtocol networkProtocol) {
-    if (isNATEnvironment()) {
+    if (isNatEnvironment()) {
       try {
         final NatManager natSystem = getNatManager().orElseThrow();
         return Optional.of(natSystem.getPortMapping(serviceType, networkProtocol));

--- a/nat/src/main/java/org/hyperledger/besu/nat/NatService.java
+++ b/nat/src/main/java/org/hyperledger/besu/nat/NatService.java
@@ -22,6 +22,8 @@ import org.hyperledger.besu.nat.upnp.UpnpNatManager;
 
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.logging.log4j.LogManager;
@@ -47,6 +49,28 @@ public class NatService {
    */
   public boolean isNatEnvironment() {
     return currentNatMethod != NatMethod.NONE;
+  }
+
+  /**
+   * If nat environment is present, performs the given action, otherwise does nothing.
+   *
+   * @param action the action to be performed, if a nat environment is present
+   */
+  public void ifNatEnvironment(final BiConsumer<? super NatService, ? super NatManager> action) {
+    if (isNatEnvironment()) {
+      currentNatManager.ifPresent(natManager -> action.accept(this, natManager));
+    }
+  }
+
+  /**
+   * If nat environment is present, performs the given action, otherwise does nothing.
+   *
+   * @param action the action to be performed, if a nat environment is present
+   */
+  public void ifNatEnvironment(final Consumer<? super NatService> action) {
+    if (isNatEnvironment()) {
+      action.accept(this);
+    }
   }
 
   /**

--- a/nat/src/main/java/org/hyperledger/besu/nat/core/AbstractNatManager.java
+++ b/nat/src/main/java/org/hyperledger/besu/nat/core/AbstractNatManager.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.nat.core;
+
+import org.hyperledger.besu.nat.NatMethod;
+import org.hyperledger.besu.nat.core.domain.NatPortMapping;
+import org.hyperledger.besu.nat.core.domain.NatServiceType;
+import org.hyperledger.besu.nat.core.domain.NetworkProtocol;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public abstract class AbstractNatManager implements NatManager {
+  protected static final Logger LOG = LogManager.getLogger();
+
+  protected final NatMethod natMethod;
+
+  protected final AtomicBoolean started = new AtomicBoolean();
+
+  protected AbstractNatManager(final NatMethod natMethod) {
+    this.natMethod = natMethod;
+  }
+
+  protected abstract void doStart();
+
+  protected abstract void doStop();
+
+  protected abstract CompletableFuture<String> retrieveExternalIPAddress();
+
+  @Override
+  public NatMethod getNatMethod() {
+    return natMethod;
+  }
+
+  @Override
+  public boolean isStarted() {
+    return started.get();
+  }
+
+  @Override
+  public CompletableFuture<String> queryExternalIPAddress() {
+    if (!isStarted()) {
+      throw new IllegalStateException("Cannot call queryExternalIPAddress() when in stopped state");
+    }
+    return retrieveExternalIPAddress();
+  }
+
+  @Override
+  public CompletableFuture<String> queryLocalIPAddress() {
+    final CompletableFuture<String> future = new CompletableFuture<>();
+    Executors.newCachedThreadPool()
+        .submit(
+            () -> {
+              try {
+                future.complete(InetAddress.getLocalHost().getHostAddress());
+              } catch (UnknownHostException e) {
+                future.completeExceptionally(e);
+              }
+            });
+    return future;
+  }
+
+  @Override
+  public void start() {
+    if (started.compareAndSet(false, true)) {
+      doStart();
+    } else {
+      LOG.warn("Attempt to start an already-started {}", getClass().getSimpleName());
+    }
+  }
+
+  @Override
+  public void stop() {
+    if (started.compareAndSet(true, false)) {
+      doStop();
+    } else {
+      LOG.warn("Attempt to stop an already-stopped {}", getClass().getSimpleName());
+    }
+  }
+
+  @Override
+  public NatPortMapping getPortMapping(
+      final NatServiceType serviceType, final NetworkProtocol networkProtocol) {
+    try {
+      final List<NatPortMapping> natPortMappings =
+          getPortMappings().get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+      final Optional<NatPortMapping> foundPortMapping =
+          natPortMappings.stream()
+              .filter(
+                  c ->
+                      c.getNatServiceType().equals(serviceType)
+                          && c.getProtocol().equals(networkProtocol))
+              .findFirst();
+      return foundPortMapping.orElseThrow();
+    } catch (NoSuchElementException e) {
+      throw new IllegalArgumentException(
+          String.format("Required service type not found : %s %s", serviceType, networkProtocol));
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      throw new RuntimeException(
+          String.format("Unable to retrieve the service type : %s", serviceType.toString()));
+    }
+  }
+}

--- a/nat/src/main/java/org/hyperledger/besu/nat/core/NatManager.java
+++ b/nat/src/main/java/org/hyperledger/besu/nat/core/NatManager.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.nat.core;
+
+import org.hyperledger.besu.nat.NatMethod;
+import org.hyperledger.besu.nat.core.domain.NatPortMapping;
+import org.hyperledger.besu.nat.core.domain.NatServiceType;
+import org.hyperledger.besu.nat.core.domain.NetworkProtocol;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * This class describes the behaviour of any supported NAT system. Internal API to support Network
+ * Address Translation (NAT) technologies in Besu.
+ */
+public interface NatManager {
+
+  int TIMEOUT_SECONDS = 60;
+
+  /**
+   * Returns the NAT method associated to this system.
+   *
+   * @return the {@link NatMethod}
+   */
+  NatMethod getNatMethod();
+
+  /** Starts the system or service. */
+  void start();
+
+  /** Stops the system or service. */
+  void stop();
+
+  /**
+   * Returns whether or not the system is started.
+   *
+   * @return true if started, false otherwise.
+   */
+  boolean isStarted();
+
+  /**
+   * Checks if the system is started and throws an {@link IllegalStateException} in case it is not
+   * started. Convenient method to perform actions only if service is started.
+   */
+  default void requireSystemStarted() {
+    if (!isStarted()) {
+      throw new IllegalStateException("NAT system must be started.");
+    }
+  }
+
+  /**
+   * Returns a {@link java.util.concurrent.Future} wrapping the local IP address.
+   *
+   * @return The local IP address wrapped in a {@link java.util.concurrent.Future}.
+   */
+  CompletableFuture<String> queryLocalIPAddress();
+
+  /**
+   * Returns a {@link java.util.concurrent.Future} wrapping the external IP address.
+   *
+   * @return The external IP address wrapped in a {@link java.util.concurrent.Future}.
+   */
+  CompletableFuture<String> queryExternalIPAddress();
+
+  /**
+   * Returns all known port mappings.
+   *
+   * @return The known port mappings wrapped in a {@link java.util.concurrent.Future}.
+   */
+  CompletableFuture<List<NatPortMapping>> getPortMappings();
+
+  /**
+   * Returns the port mapping associated to the passed service type.
+   *
+   * @param serviceType The service type {@link NatServiceType}.
+   * @param networkProtocol The network protocol {@link NetworkProtocol}.
+   * @return The port mapping {@link NatPortMapping}
+   */
+  NatPortMapping getPortMapping(
+      final NatServiceType serviceType, final NetworkProtocol networkProtocol);
+}

--- a/nat/src/main/java/org/hyperledger/besu/nat/core/domain/NatPortMapping.java
+++ b/nat/src/main/java/org/hyperledger/besu/nat/core/domain/NatPortMapping.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.hyperledger.besu.nat.core.domain;
+
+/** This class describes a NAT configuration. */
+public class NatPortMapping {
+
+  private final NatServiceType natServiceType;
+  private final NetworkProtocol protocol;
+  private final String internalHost;
+  private final String remoteHost;
+  private final int externalPort;
+  private final int internalPort;
+
+  public NatPortMapping(
+      final NatServiceType natServiceType,
+      final NetworkProtocol protocol,
+      final String internalHost,
+      final String remoteHost,
+      final int externalPort,
+      final int internalPort) {
+    this.natServiceType = natServiceType;
+    this.protocol = protocol;
+    this.internalHost = internalHost;
+    this.remoteHost = remoteHost;
+    this.externalPort = externalPort;
+    this.internalPort = internalPort;
+  }
+
+  /**
+   * Builds an empty representation of a {@link NatPortMapping}
+   *
+   * @param protocol the {@link NetworkProtocol} associated to the representation.
+   * @return the built {@link NatPortMapping}
+   */
+  public static NatPortMapping emptyPortMapping(final NetworkProtocol protocol) {
+    return new NatPortMapping(null, protocol, "", "", 0, 0);
+  }
+
+  public NatServiceType getNatServiceType() {
+    return natServiceType;
+  }
+
+  public NetworkProtocol getProtocol() {
+    return protocol;
+  }
+
+  public String getInternalHost() {
+    return internalHost;
+  }
+
+  public String getRemoteHost() {
+    return remoteHost;
+  }
+
+  public int getExternalPort() {
+    return externalPort;
+  }
+
+  public int getInternalPort() {
+    return internalPort;
+  }
+
+  @Override
+  public String toString() {
+    return String.format(
+        "[%s - %s] %s:%d ==> %s:%d",
+        natServiceType, protocol, internalHost, internalPort, remoteHost, externalPort);
+  }
+}

--- a/nat/src/main/java/org/hyperledger/besu/nat/core/domain/NatServiceType.java
+++ b/nat/src/main/java/org/hyperledger/besu/nat/core/domain/NatServiceType.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.hyperledger.besu.nat.core.domain;
+
+/**
+ * This enum describes the types of services that could be impacted by the {@link
+ * org.hyperledger.besu.nat.NatMethod} used by the Besu node.
+ *
+ * <ul>
+ *   <li><b>JSON_RPC:</b> Ethereum JSON-RPC HTTP service.
+ *   <li><b>RLPX:</b> Peer to Peer network layer.
+ *   <li><b>DISCOVERY:</b> Peer to Peer discovery layer.
+ * </ul>
+ */
+public enum NatServiceType {
+  JSON_RPC("json-rpc"),
+  RLPX("rlpx"),
+  DISCOVERY("discovery");
+
+  private final String value;
+
+  NatServiceType(final String value) {
+    this.value = value;
+  }
+
+  /**
+   * Parses and returns corresponding enum value to the passed method name. This method throws an
+   * {@link IllegalStateException} if the method name is invalid.
+   *
+   * @param natServiceTypeName The name of the NAT service type.
+   * @return The corresponding {@link NatServiceType}
+   */
+  public static NatServiceType fromString(final String natServiceTypeName) {
+    for (final NatServiceType mode : NatServiceType.values()) {
+      if (mode.getValue().equalsIgnoreCase(natServiceTypeName)) {
+        return mode;
+      }
+    }
+    throw new IllegalStateException(
+        String.format("Invalid NAT service type provided: %s", natServiceTypeName));
+  }
+
+  public String getValue() {
+    return value;
+  }
+}

--- a/nat/src/main/java/org/hyperledger/besu/nat/core/domain/NetworkProtocol.java
+++ b/nat/src/main/java/org/hyperledger/besu/nat/core/domain/NetworkProtocol.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.hyperledger.besu.nat.core.domain;
+
+/**
+ * This enum describes all supported NAT methods in Besu.
+ *
+ * <ul>
+ *   <li><b>TCP:</b> Transmission Control Protocol.
+ *   <li><b>UDP:</b> User Datagram Protocol.
+ * </ul>
+ */
+public enum NetworkProtocol {
+  TCP,
+  UDP
+}

--- a/nat/src/test/java/org/hyperledger/besu/nat/NatServiceTest.java
+++ b/nat/src/test/java/org/hyperledger/besu/nat/NatServiceTest.java
@@ -53,10 +53,10 @@ public class NatServiceTest {
   @Test
   public void assertThatIsNatEnvironmentReturnCorrectStatus() {
     final NatService nonNatService = new NatService(NatMethod.NONE);
-    assertThat(nonNatService.isNATEnvironment()).isFalse();
+    assertThat(nonNatService.isNatEnvironment()).isFalse();
 
     final NatService upnpNatService = new NatService(NatMethod.UPNP);
-    assertThat(upnpNatService.isNATEnvironment()).isTrue();
+    assertThat(upnpNatService.isNatEnvironment()).isTrue();
   }
 
   @SuppressWarnings("OptionalGetWithoutIsPresent")

--- a/nat/src/test/java/org/hyperledger/besu/nat/NatServiceTest.java
+++ b/nat/src/test/java/org/hyperledger/besu/nat/NatServiceTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.hyperledger.besu.nat;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.hyperledger.besu.nat.core.NatManager;
+import org.hyperledger.besu.nat.core.domain.NatPortMapping;
+import org.hyperledger.besu.nat.core.domain.NatServiceType;
+import org.hyperledger.besu.nat.core.domain.NetworkProtocol;
+import org.hyperledger.besu.nat.upnp.UpnpNatManager;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class NatServiceTest {
+
+  @SuppressWarnings("OptionalGetWithoutIsPresent")
+  @Test
+  public void assertThatGetNatSystemReturnValidSystem() {
+    final NatService natService = new NatService(NatMethod.UPNP);
+    assertThat(natService.getNatManager().get()).isInstanceOf(UpnpNatManager.class);
+  }
+
+  @Test
+  public void assertThatGetNatSystemNotReturnSystemWhenNatMethodIsNone() {
+    final NatService natService = new NatService(NatMethod.NONE);
+    assertThat(natService.getNatManager()).isNotPresent();
+  }
+
+  @Test
+  public void assertThatIsNatEnvironmentReturnCorrectStatus() {
+    final NatService nonNatService = new NatService(NatMethod.NONE);
+    assertThat(nonNatService.isNATEnvironment()).isFalse();
+
+    final NatService upnpNatService = new NatService(NatMethod.UPNP);
+    assertThat(upnpNatService.isNATEnvironment()).isTrue();
+  }
+
+  @SuppressWarnings("OptionalGetWithoutIsPresent")
+  @Test
+  public void assertThatGetPortMappingWorksProperlyWithUpNp() {
+    final String externalIp = "127.0.0.3";
+    final NatPortMapping natPortMapping =
+        new NatPortMapping(
+            NatServiceType.DISCOVERY, NetworkProtocol.UDP, externalIp, externalIp, 1111, 1111);
+    final NatManager natSystem = mock(NatManager.class);
+    when(natSystem.getPortMapping(natPortMapping.getNatServiceType(), natPortMapping.getProtocol()))
+        .thenReturn(natPortMapping);
+
+    final NatService natService = new NatService(NatMethod.UPNP);
+    natService.setNatSystem(natSystem);
+
+    final Optional<NatPortMapping> portMapping =
+        natService.getPortMapping(natPortMapping.getNatServiceType(), natPortMapping.getProtocol());
+
+    verify(natSystem)
+        .getPortMapping(natPortMapping.getNatServiceType(), natPortMapping.getProtocol());
+
+    Assertions.assertThat(portMapping.get()).isEqualTo(natPortMapping);
+  }
+
+  @Test
+  public void assertThatGetPortMappingWorksProperlyWithoutNat() {
+
+    final NatService natService = new NatService(NatMethod.NONE);
+
+    final Optional<NatPortMapping> portMapping =
+        natService.getPortMapping(NatServiceType.DISCOVERY, NetworkProtocol.TCP);
+
+    Assertions.assertThat(portMapping).isNotPresent();
+  }
+
+  @SuppressWarnings("OptionalGetWithoutIsPresent")
+  @Test
+  public void assertQueryExternalIpWorksProperlyWithUpNp() {
+    final String externalIp = "127.0.0.3";
+    final NatManager natManager = mock(NatManager.class);
+    when(natManager.queryExternalIPAddress())
+        .thenReturn(CompletableFuture.completedFuture(externalIp));
+
+    final NatService natService = new NatService(NatMethod.UPNP);
+    natService.setNatSystem(natManager);
+
+    final Optional<String> resultIp = natService.queryExternalIPAddress();
+
+    verify(natManager).queryExternalIPAddress();
+
+    Assertions.assertThat(resultIp.get()).isEqualTo(externalIp);
+  }
+
+  @Test
+  public void assertThatQueryExternalIpWorksProperlyWithoutNat() {
+
+    final NatService natService = new NatService(NatMethod.NONE);
+
+    final Optional<String> resultIp = natService.queryExternalIPAddress();
+
+    Assertions.assertThat(resultIp).isNotPresent();
+  }
+
+  @SuppressWarnings("OptionalGetWithoutIsPresent")
+  @Test
+  public void assertThatQueryLocalIPAddressWorksProperlyWithUpNp() {
+    final String externalIp = "127.0.0.3";
+    final NatManager natManager = mock(NatManager.class);
+    when(natManager.queryLocalIPAddress())
+        .thenReturn(CompletableFuture.completedFuture(externalIp));
+
+    final NatService natService = new NatService(NatMethod.UPNP);
+    natService.setNatSystem(natManager);
+
+    final Optional<String> resultIp = natService.queryLocalIPAddress();
+
+    verify(natManager).queryLocalIPAddress();
+
+    Assertions.assertThat(resultIp.get()).isEqualTo(externalIp);
+  }
+
+  @Test
+  public void assertThatQueryLocalIPAddressWorksProperlyWithoutNat() {
+
+    final NatService natService = new NatService(NatMethod.NONE);
+
+    final Optional<String> resultIp = natService.queryLocalIPAddress();
+
+    Assertions.assertThat(resultIp).isNotPresent();
+  }
+}

--- a/nat/src/test/java/org/hyperledger/besu/nat/NatServiceTest.java
+++ b/nat/src/test/java/org/hyperledger/besu/nat/NatServiceTest.java
@@ -18,6 +18,7 @@ package org.hyperledger.besu.nat;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.nat.core.NatManager;
@@ -28,6 +29,8 @@ import org.hyperledger.besu.nat.upnp.UpnpNatManager;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
@@ -57,6 +60,44 @@ public class NatServiceTest {
 
     final NatService upnpNatService = new NatService(NatMethod.UPNP);
     assertThat(upnpNatService.isNatEnvironment()).isTrue();
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void assertThatIfNatEnvironmentWorksProperlyWithUpNp() {
+
+    final NatManager natSystem = mock(NatManager.class);
+
+    final NatService natService = new NatService(NatMethod.UPNP);
+    natService.setNatSystem(natSystem);
+
+    final Consumer<NatService> consumer = mock(Consumer.class);
+    natService.ifNatEnvironment(consumer);
+
+    final BiConsumer<NatService, NatManager> biConsumer = mock(BiConsumer.class);
+    natService.ifNatEnvironment(biConsumer);
+
+    verify(consumer).accept(natService);
+    verify(biConsumer).accept(natService, natSystem);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void assertThatIfNatEnvironmentWorksProperlyWithoutNat() {
+
+    final NatManager natSystem = mock(NatManager.class);
+
+    final NatService natService = new NatService(NatMethod.NONE);
+    natService.setNatSystem(natSystem);
+
+    final Consumer<NatService> consumer = mock(Consumer.class);
+    natService.ifNatEnvironment(consumer);
+
+    final BiConsumer<NatService, NatManager> biConsumer = mock(BiConsumer.class);
+    natService.ifNatEnvironment(biConsumer);
+
+    verifyNoInteractions(consumer);
+    verifyNoInteractions(biConsumer);
   }
 
   @SuppressWarnings("OptionalGetWithoutIsPresent")

--- a/nat/src/test/java/org/hyperledger/besu/nat/core/AbstractNATSystemTest.java
+++ b/nat/src/test/java/org/hyperledger/besu/nat/core/AbstractNATSystemTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.hyperledger.besu.nat.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.hyperledger.besu.nat.NatMethod;
+import org.hyperledger.besu.nat.core.domain.NatPortMapping;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AbstractNATSystemTest {
+
+  @Test
+  public void assertThatSystemIsStartedAfterStart() {
+    final AbstractNatManager natSystem = buildNATSystem(NatMethod.UPNP);
+    assertThat(natSystem.isStarted()).isFalse();
+    natSystem.start();
+    assertThat(natSystem.isStarted()).isTrue();
+  }
+
+  @Test
+  public void assertThatSystemIsStoppedAfterStopped() {
+    final AbstractNatManager natSystem = buildNATSystem(NatMethod.UPNP);
+    assertThat(natSystem.isStarted()).isFalse();
+    natSystem.start();
+    assertThat(natSystem.isStarted()).isTrue();
+    natSystem.stop();
+    assertThat(natSystem.isStarted()).isFalse();
+  }
+
+  @Test
+  public void assertThatDoStartIsCalledOnlyOnce() {
+    final AbstractNatManager natSystem = Mockito.spy(buildNATSystem(NatMethod.UPNP));
+    natSystem.start();
+    natSystem.start();
+    verify(natSystem, times(2)).start();
+    verify(natSystem).doStart();
+  }
+
+  @Test
+  public void assertThatDoStopIsCalledOnlyOnce() {
+    final AbstractNatManager natSystem = Mockito.spy(buildNATSystem(NatMethod.UPNP));
+    natSystem.start();
+    natSystem.stop();
+    natSystem.stop();
+    verify(natSystem).start();
+    verify(natSystem).doStart();
+    verify(natSystem, times(2)).stop();
+    verify(natSystem).doStop();
+  }
+
+  @Test
+  public void assertThatRequireSystemStartedThrowExceptionIfNotStarted() {
+    assertThatThrownBy(() -> buildNATSystem(NatMethod.UPNP).requireSystemStarted())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("NAT system must be started.");
+  }
+
+  @Test
+  public void assertThatSystemReturnValidNatMethod() {
+    assertThat(buildNATSystem(NatMethod.UPNP).getNatMethod()).isEqualTo(NatMethod.UPNP);
+  }
+
+  @Test
+  public void assertThatSystemReturnValidLocalIpAddress()
+      throws UnknownHostException, ExecutionException, InterruptedException {
+    final String hostAddress = InetAddress.getLocalHost().getHostAddress();
+    assertThat(buildNATSystem(NatMethod.UPNP).queryLocalIPAddress().get()).isEqualTo(hostAddress);
+  }
+
+  private static AbstractNatManager buildNATSystem(final NatMethod natMethod) {
+    return new AbstractNatManager(natMethod) {
+      @Override
+      public void doStart() {}
+
+      @Override
+      public void doStop() {}
+
+      @Override
+      protected CompletableFuture<String> retrieveExternalIPAddress() {
+        return new CompletableFuture<>();
+      }
+
+      @Override
+      public CompletableFuture<List<NatPortMapping>> getPortMappings() {
+        return new CompletableFuture<>();
+      }
+    };
+  }
+}

--- a/nat/src/test/java/org/hyperledger/besu/nat/upnp/UpnpNatManagerTest.java
+++ b/nat/src/test/java/org/hyperledger/besu/nat/upnp/UpnpNatManagerTest.java
@@ -122,7 +122,7 @@ public final class UpnpNatManagerTest {
   }
 
   @Test
-  public void queryExternalIPAddressThrowsWhenStopped() throws Exception {
+  public void queryIpThrowsWhenStopped() throws Exception {
 
     assertThatThrownBy(
             () -> {
@@ -132,7 +132,7 @@ public final class UpnpNatManagerTest {
   }
 
   @Test
-  public void queryExternalIPAddressDoesNotThrowWhenStarted() throws Exception {
+  public void queryIpDoesNotThrowWhenStarted() throws Exception {
     upnpManager.start();
 
     upnpManager.queryExternalIPAddress();

--- a/nat/src/test/java/org/hyperledger/besu/nat/upnp/UpnpNatManagerTest.java
+++ b/nat/src/test/java/org/hyperledger/besu/nat/upnp/UpnpNatManagerTest.java
@@ -22,6 +22,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import org.hyperledger.besu.nat.core.domain.NatServiceType;
+import org.hyperledger.besu.nat.core.domain.NetworkProtocol;
+
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.URL;
@@ -104,7 +107,7 @@ public final class UpnpNatManagerTest {
 
     assertThatThrownBy(
             () -> {
-              upnpManager.requestPortForward(80, UpnpNatManager.Protocol.TCP, "");
+              upnpManager.requestPortForward(80, NetworkProtocol.TCP, NatServiceType.DISCOVERY);
             })
         .isInstanceOf(IllegalStateException.class);
   }
@@ -113,12 +116,13 @@ public final class UpnpNatManagerTest {
   public void requestPortForwardThrowsWhenPortIsZero() {
     upnpManager.start();
 
-    assertThatThrownBy(() -> upnpManager.requestPortForward(0, UpnpNatManager.Protocol.TCP, ""))
+    assertThatThrownBy(
+            () -> upnpManager.requestPortForward(0, NetworkProtocol.TCP, NatServiceType.DISCOVERY))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
-  public void queryIpThrowsWhenStopped() throws Exception {
+  public void queryExternalIPAddressThrowsWhenStopped() throws Exception {
 
     assertThatThrownBy(
             () -> {
@@ -128,7 +132,7 @@ public final class UpnpNatManagerTest {
   }
 
   @Test
-  public void queryIpDoesNotThrowWhenStarted() throws Exception {
+  public void queryExternalIPAddressDoesNotThrowWhenStarted() throws Exception {
     upnpManager.start();
 
     upnpManager.queryExternalIPAddress();


### PR DESCRIPTION
## PR description

Create a general internal API to support Network Address Translation (NAT) technologies in Besu. The goal of this work is to offer developers a consistent API for performing NAT tasks so that I can abstractly add support for new NAT systems (e.g. Docker, Kubernetes, etc.) with a minimum amount of code changes. As a second NAT style, explicit configuration for all ports and IP addresses would be available.

## Changes list

- Remove optional for NatService (Runner, RunnerBuilder, JsonRpcHttpService, PeerDiscoveryAgent, VertxPeerDiscoveryAgent, DefaultP2PNetwork)
- Update test to remove Optional
- Add ifNatEnvrionment(Consumer) and ifNatEnvironment(BiConsumer) to the NatService class in order to improve code readability