### PR TITLE
[PR3] Add manual NAT settings

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
@@ -328,8 +328,7 @@ public class RunnerBuilder {
             .map(nodePerms -> PeerPermissions.combine(nodePerms, bannedNodes))
             .orElse(bannedNodes);
 
-    final Optional<NatService> natService =
-        Optional.of(NatService.builder().natManager(buildNatManager(natMethod)).build());
+    final Optional<NatService> natService = Optional.of(new NatService(buildNatManager(natMethod)));
 
     NetworkBuilder inactiveNetwork = (caps) -> new NoopP2PNetwork();
     NetworkBuilder activeNetwork =

--- a/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
@@ -563,7 +563,8 @@ public class RunnerBuilder {
       case UPNP:
         return Optional.of(new UpnpNatManager());
       case MANUAL:
-        return Optional.of(new ManualNatManager(p2pAdvertisedHost, p2pListenPort));
+        return Optional.of(
+            new ManualNatManager(p2pAdvertisedHost, p2pListenPort, jsonRpcConfiguration.getPort()));
       case NONE:
       default:
         return Optional.empty();

--- a/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
@@ -88,6 +88,9 @@ import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
 import org.hyperledger.besu.metrics.prometheus.MetricsService;
 import org.hyperledger.besu.nat.NatMethod;
 import org.hyperledger.besu.nat.NatService;
+import org.hyperledger.besu.nat.core.NatManager;
+import org.hyperledger.besu.nat.manual.ManualNatManager;
+import org.hyperledger.besu.nat.upnp.UpnpNatManager;
 import org.hyperledger.besu.util.NetworkUtility;
 import org.hyperledger.besu.util.bytes.BytesValue;
 
@@ -326,7 +329,7 @@ public class RunnerBuilder {
             .orElse(bannedNodes);
 
     final Optional<NatService> natService =
-        Optional.of(NatService.builder().natMethod(natMethod).build());
+        Optional.of(NatService.builder().natManager(buildNatManager(natMethod)).build());
 
     NetworkBuilder inactiveNetwork = (caps) -> new NoopP2PNetwork();
     NetworkBuilder activeNetwork =
@@ -552,6 +555,18 @@ public class RunnerBuilder {
       return accountPermissioningController;
     } else {
       return Optional.empty();
+    }
+  }
+
+  private Optional<NatManager> buildNatManager(final NatMethod natMethod) {
+    switch (natMethod) {
+      case UPNP:
+        return Optional.of(new UpnpNatManager());
+      case MANUAL:
+        return Optional.of(new ManualNatManager(p2pAdvertisedHost, p2pListenPort));
+      case NONE:
+      default:
+        return Optional.empty();
     }
   }
 

--- a/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -1398,7 +1398,7 @@ public class BesuCommandTest extends CommandTestAbstract {
     assertThat(commandOutput.toString()).isEmpty();
     assertThat(commandErrorOutput.toString())
         .contains(
-            "Invalid value for option '--nat-method': expected one of [UPNP, NONE] (case-insensitive) but was 'invalid'");
+            "Invalid value for option '--nat-method': expected one of [UPNP, MANUAL, NONE] (case-insensitive) but was 'invalid'");
   }
 
   @Test

--- a/nat/src/main/java/org/hyperledger/besu/nat/NatMethod.java
+++ b/nat/src/main/java/org/hyperledger/besu/nat/NatMethod.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.nat;
 
 public enum NatMethod {
   UPNP,
+  MANUAL,
   NONE;
 
   public static NatMethod fromString(final String str) {

--- a/nat/src/main/java/org/hyperledger/besu/nat/NatService.java
+++ b/nat/src/main/java/org/hyperledger/besu/nat/NatService.java
@@ -20,7 +20,6 @@ import org.hyperledger.besu.nat.core.NatManager;
 import org.hyperledger.besu.nat.core.domain.NatPortMapping;
 import org.hyperledger.besu.nat.core.domain.NatServiceType;
 import org.hyperledger.besu.nat.core.domain.NetworkProtocol;
-import org.hyperledger.besu.nat.upnp.UpnpNatManager;
 
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -170,27 +169,16 @@ public class NatService {
   }
 
   public static class Builder {
-    private NatMethod natMethod = NatMethod.NONE;
+    private Optional<NatManager> natManager = Optional.empty();
 
-    public Builder natMethod(final NatMethod natMethod) {
-      checkNotNull(natMethod);
-      this.natMethod = natMethod;
+    public Builder natManager(final Optional<NatManager> natManager) {
+      checkNotNull(natManager);
+      this.natManager = natManager;
       return this;
     }
 
     public NatService build() {
-      return new NatService(buildNatManager(natMethod));
-    }
-
-    /** Initialize the current NatManager. */
-    private Optional<NatManager> buildNatManager(final NatMethod givenNatMethod) {
-      switch (givenNatMethod) {
-        case UPNP:
-          return Optional.of(new UpnpNatManager());
-        case NONE:
-        default:
-          return Optional.empty();
-      }
+      return new NatService(natManager);
     }
   }
 }

--- a/nat/src/main/java/org/hyperledger/besu/nat/NatService.java
+++ b/nat/src/main/java/org/hyperledger/besu/nat/NatService.java
@@ -14,8 +14,6 @@
  */
 package org.hyperledger.besu.nat;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import org.hyperledger.besu.nat.core.NatManager;
 import org.hyperledger.besu.nat.core.domain.NatPortMapping;
 import org.hyperledger.besu.nat.core.domain.NatServiceType;
@@ -75,6 +73,8 @@ public class NatService {
       } catch (Exception e) {
         LOG.warn("Caught exception while trying to start the manager or service", e);
       }
+    } else {
+      LOG.info("No NAT environment detected so no service could be started");
     }
   }
 
@@ -86,6 +86,8 @@ public class NatService {
       } catch (Exception e) {
         LOG.warn("Caught exception while trying to stop the manager or service", e);
       }
+    } else {
+      LOG.info("No NAT environment detected so no service could be stopped");
     }
   }
 
@@ -162,23 +164,5 @@ public class NatService {
    */
   private NatMethod retrieveNatMethod(final Optional<NatManager> natManager) {
     return natManager.map(NatManager::getNatMethod).orElse(NatMethod.NONE);
-  }
-
-  public static Builder builder() {
-    return new Builder();
-  }
-
-  public static class Builder {
-    private Optional<NatManager> natManager = Optional.empty();
-
-    public Builder natManager(final Optional<NatManager> natManager) {
-      checkNotNull(natManager);
-      this.natManager = natManager;
-      return this;
-    }
-
-    public NatService build() {
-      return new NatService(natManager);
-    }
   }
 }

--- a/nat/src/main/java/org/hyperledger/besu/nat/manual/ManualNatManager.java
+++ b/nat/src/main/java/org/hyperledger/besu/nat/manual/ManualNatManager.java
@@ -1,0 +1,72 @@
+package org.hyperledger.besu.nat.manual;
+
+import static java.util.Arrays.stream;
+
+import org.hyperledger.besu.nat.NatMethod;
+import org.hyperledger.besu.nat.core.AbstractNatManager;
+import org.hyperledger.besu.nat.core.domain.NatPortMapping;
+import org.hyperledger.besu.nat.core.domain.NatServiceType;
+import org.hyperledger.besu.nat.core.domain.NetworkProtocol;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+public class ManualNatManager extends AbstractNatManager {
+
+  private final String remoteHost;
+  private final int port;
+  private final List<NatPortMapping> forwardedPorts;
+
+  public ManualNatManager(final String remoteHost, final int port) {
+    super(NatMethod.MANUAL);
+    this.remoteHost = remoteHost;
+    this.port = port;
+    forwardedPorts = buildForwardedPorts();
+  }
+
+  private List<NatPortMapping> buildForwardedPorts() {
+    final List<NatPortMapping> natPortMappings = new ArrayList<>();
+    try {
+      final String internalHost = queryLocalIPAddress().get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+      stream(NatServiceType.values())
+          .forEach(
+              natServiceType ->
+                  stream(NetworkProtocol.values())
+                      .forEach(
+                          networkProtocol ->
+                              natPortMappings.add(
+                                  new NatPortMapping(
+                                      natServiceType,
+                                      networkProtocol,
+                                      internalHost,
+                                      remoteHost,
+                                      port,
+                                      port))));
+    } catch (Exception e) {
+      LOG.info("Failed to create forwarded port list");
+    }
+    return natPortMappings;
+  }
+
+  @Override
+  protected void doStart() {
+    LOG.info("Starting Manual NatManager");
+  }
+
+  @Override
+  protected void doStop() {
+    LOG.info("Stopping Manual NatManager");
+  }
+
+  @Override
+  protected CompletableFuture<String> retrieveExternalIPAddress() {
+    return CompletableFuture.completedFuture(remoteHost);
+  }
+
+  @Override
+  public CompletableFuture<List<NatPortMapping>> getPortMappings() {
+    return CompletableFuture.completedFuture(forwardedPorts);
+  }
+}

--- a/nat/src/main/java/org/hyperledger/besu/nat/manual/ManualNatManager.java
+++ b/nat/src/main/java/org/hyperledger/besu/nat/manual/ManualNatManager.java
@@ -13,6 +13,11 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * This class describes the behaviour of the Manual NAT manager. Manual Nat manager add the ability
+ * to explicitly configure the external IP and Ports to broadcast without regards to NAT or other
+ * considerations.
+ */
 public class ManualNatManager extends AbstractNatManager {
 
   private final String remoteHost;

--- a/nat/src/main/java/org/hyperledger/besu/nat/manual/ManualNatManager.java
+++ b/nat/src/main/java/org/hyperledger/besu/nat/manual/ManualNatManager.java
@@ -29,7 +29,7 @@ public class ManualNatManager extends AbstractNatManager {
     this.advertisedHost = advertisedHost;
     this.p2pPort = p2pPort;
     this.rpcHttpPort = rpcHttpPort;
-    forwardedPorts = buildForwardedPorts();
+    this.forwardedPorts = buildForwardedPorts();
   }
 
   private List<NatPortMapping> buildForwardedPorts() {
@@ -58,7 +58,7 @@ public class ManualNatManager extends AbstractNatManager {
               rpcHttpPort,
               rpcHttpPort));
     } catch (Exception e) {
-      LOG.info("Failed to create forwarded port list");
+      LOG.warn("Failed to create forwarded port list", e);
     }
     return Collections.emptyList();
   }

--- a/nat/src/main/java/org/hyperledger/besu/nat/upnp/UpnpNatManager.java
+++ b/nat/src/main/java/org/hyperledger/besu/nat/upnp/UpnpNatManager.java
@@ -19,7 +19,6 @@ import static com.google.common.base.Preconditions.checkState;
 
 import org.hyperledger.besu.nat.NatMethod;
 import org.hyperledger.besu.nat.core.AbstractNatManager;
-import org.hyperledger.besu.nat.core.NatManager;
 import org.hyperledger.besu.nat.core.domain.NatPortMapping;
 import org.hyperledger.besu.nat.core.domain.NatServiceType;
 import org.hyperledger.besu.nat.core.domain.NetworkProtocol;
@@ -56,7 +55,7 @@ import org.jupnp.support.model.PortMapping;
  * Manages underlying UPnP library "jupnp" and provides abstractions for asynchronously interacting
  * with the NAT environment through UPnP.
  */
-public class UpnpNatManager extends AbstractNatManager implements NatManager {
+public class UpnpNatManager extends AbstractNatManager {
   protected static final Logger LOG = LogManager.getLogger();
 
   static final String SERVICE_TYPE_WAN_IP_CONNECTION = "WANIPConnection";

--- a/nat/src/test/java/org/hyperledger/besu/nat/manual/ManualNatManagerTest.java
+++ b/nat/src/test/java/org/hyperledger/besu/nat/manual/ManualNatManagerTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.hyperledger.besu.nat.manual;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.hyperledger.besu.nat.core.domain.NatPortMapping;
+import org.hyperledger.besu.nat.core.domain.NatServiceType;
+import org.hyperledger.besu.nat.core.domain.NetworkProtocol;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.concurrent.ExecutionException;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ManualNatManagerTest {
+
+  private final String advertisedHost = "99.45.69.12";
+  private final int p2pPort = 1;
+  private final int rpcHttpPort = 2;
+
+  private ManualNatManager natManager;
+
+  @Before
+  public void initialize() {
+    natManager = new ManualNatManager(advertisedHost, p2pPort, rpcHttpPort);
+    natManager.start();
+  }
+
+  @Test
+  public void assertThatExternalIPIsEqualToRemoteHost()
+      throws ExecutionException, InterruptedException {
+    assertThat(natManager.queryExternalIPAddress().get()).isEqualTo(advertisedHost);
+  }
+
+  @Test
+  public void assertThatLocalIPIsEqualToLocalHost()
+      throws ExecutionException, InterruptedException, UnknownHostException {
+    final String internalHost = InetAddress.getLocalHost().getHostAddress();
+    assertThat(natManager.queryLocalIPAddress().get()).isEqualTo(internalHost);
+  }
+
+  @Test
+  public void assertThatMappingForDiscoveryWorks() throws UnknownHostException {
+    final String internalHost = InetAddress.getLocalHost().getHostAddress();
+
+    final NatPortMapping mapping =
+        natManager.getPortMapping(NatServiceType.DISCOVERY, NetworkProtocol.UDP);
+
+    final NatPortMapping expectedMapping =
+        new NatPortMapping(
+            NatServiceType.DISCOVERY,
+            NetworkProtocol.UDP,
+            internalHost,
+            advertisedHost,
+            p2pPort,
+            p2pPort);
+
+    assertThat(mapping).isEqualToComparingFieldByField(expectedMapping);
+  }
+
+  @Test
+  public void assertThatMappingForJsonRpcWorks() throws UnknownHostException {
+    final String internalHost = InetAddress.getLocalHost().getHostAddress();
+
+    final NatPortMapping mapping =
+        natManager.getPortMapping(NatServiceType.JSON_RPC, NetworkProtocol.TCP);
+
+    final NatPortMapping expectedMapping =
+        new NatPortMapping(
+            NatServiceType.JSON_RPC,
+            NetworkProtocol.TCP,
+            internalHost,
+            advertisedHost,
+            rpcHttpPort,
+            rpcHttpPort);
+
+    assertThat(mapping).isEqualToComparingFieldByField(expectedMapping);
+  }
+
+  @Test
+  public void assertThatMappingForRlpxWorks() throws UnknownHostException {
+    final String internalHost = InetAddress.getLocalHost().getHostAddress();
+
+    final NatPortMapping mapping =
+        natManager.getPortMapping(NatServiceType.RLPX, NetworkProtocol.TCP);
+
+    final NatPortMapping expectedMapping =
+        new NatPortMapping(
+            NatServiceType.RLPX,
+            NetworkProtocol.TCP,
+            internalHost,
+            advertisedHost,
+            p2pPort,
+            p2pPort);
+
+    assertThat(mapping).isEqualToComparingFieldByField(expectedMapping);
+  }
+}


### PR DESCRIPTION
Signed-off-by: Karim TAAM karim.t2am@gmail.com

## PR description

Ability to explicitly configure the external IP to broadcast without regards to NAT or other considerations.

## Changes list

- Adding a new NatMethod `Manual`
- Modification of the `NatService` builder. It will take directly the `NatManager` and not the method
- Creation of a `ManualNatManager` class that inherits from the` AbstractNatManager` class.

This class will define the ports and IP to broadcast. Here is the list of command line parameters that will be used
- For ports it's `p2p-port` and` rpc-http-port` parameters
- For the IP it is `p2p-host`
