### PR TITLE
[BESU-696] Rename gas remaining to gas refund

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/processor/TransactionTrace.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/processor/TransactionTrace.java
@@ -38,7 +38,7 @@ public class TransactionTrace {
   }
 
   public long getGas() {
-    return transaction.getGasLimit() - result.getGasRemaining();
+    return transaction.getGasLimit() - result.getGasRefund();
   }
 
   public long getGasLimit() {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/flat/FlatTraceGenerator.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/flat/FlatTraceGenerator.java
@@ -509,7 +509,7 @@ public class FlatTraceGenerator {
     if (tracesContexts.size() == 1) {
       gasRemainingBeforeProcessed =
           transactionTrace.getTraceFrames().get(0).getGasRemaining().toLong();
-      gasRemainingAfterProcessed = transactionTrace.getResult().getGasRemaining();
+      gasRemainingAfterProcessed = transactionTrace.getResult().getGasRefund();
       if (gasRemainingAfterProcessed > traceFrame.getGasRemaining().toLong()) {
         gasRefund = gasRemainingAfterProcessed - traceFrame.getGasRemaining().toLong();
       }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceTransactionTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceTransactionTest.java
@@ -107,7 +107,7 @@ public class DebugTraceTransactionTest {
     final TransactionTrace transactionTrace =
         new TransactionTrace(transaction, result, traceFrames);
     when(transaction.getGasLimit()).thenReturn(100L);
-    when(result.getGasRemaining()).thenReturn(27L);
+    when(result.getGasRefund()).thenReturn(27L);
     when(result.getOutput()).thenReturn(Bytes.fromHexString("1234"));
     when(blockHeader.getNumber()).thenReturn(12L);
     when(blockchain.headBlockNumber()).thenReturn(12L);
@@ -164,7 +164,7 @@ public class DebugTraceTransactionTest {
     final TransactionTrace transactionTrace =
         new TransactionTrace(transaction, result, traceFrames);
     when(transaction.getGasLimit()).thenReturn(100L);
-    when(result.getGasRemaining()).thenReturn(27L);
+    when(result.getGasRefund()).thenReturn(27L);
     when(result.getOutput()).thenReturn(Bytes.fromHexString("1234"));
     when(blockHeader.getNumber()).thenReturn(12L);
     when(blockchain.headBlockNumber()).thenReturn(12L);

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/BlockTransactionSelector.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/BlockTransactionSelector.java
@@ -237,7 +237,7 @@ public class BlockTransactionSelector {
    */
   private void updateTransactionResultTracking(
       final Transaction transaction, final TransactionProcessor.Result result) {
-    final long gasUsedByTransaction = transaction.getGasLimit() - result.getGasRemaining();
+    final long gasUsedByTransaction = transaction.getGasLimit() - result.getGasRefund();
     final long cumulativeGasUsed;
     if (ExperimentalEIPs.eip1559Enabled && eip1559.isPresent()) {
       cumulativeGasUsed =

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessor.java
@@ -152,7 +152,7 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
       }
 
       worldStateUpdater.commit();
-      gasUsed = transaction.getGasLimit() - result.getGasRemaining() + gasUsed;
+      gasUsed = transaction.getGasLimit() - result.getGasRefund() + gasUsed;
       final TransactionReceipt transactionReceipt =
           transactionReceiptFactory.create(result, worldState, gasUsed);
       receipts.add(transactionReceipt);

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
@@ -125,7 +125,7 @@ public class MainnetTransactionProcessor implements TransactionProcessor {
     }
 
     @Override
-    public long getGasRemaining() {
+    public long getGasRefund() {
       return gasRemaining;
     }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
@@ -67,7 +67,7 @@ public class MainnetTransactionProcessor implements TransactionProcessor {
 
     private final Status status;
 
-    private final long gasRemaining;
+    private final long gasRefund;
 
     private final List<Log> logs;
 
@@ -83,13 +83,13 @@ public class MainnetTransactionProcessor implements TransactionProcessor {
     }
 
     public static Result failed(
-        final long gasRemaining,
+        final long gasRefund,
         final ValidationResult<TransactionValidator.TransactionInvalidReason> validationResult,
         final Optional<Bytes> revertReason) {
       return new Result(
           Status.FAILED,
           new ArrayList<>(),
-          gasRemaining,
+          gasRefund,
           Bytes.EMPTY,
           validationResult,
           revertReason);
@@ -97,23 +97,23 @@ public class MainnetTransactionProcessor implements TransactionProcessor {
 
     public static Result successful(
         final List<Log> logs,
-        final long gasRemaining,
+        final long gasRefund,
         final Bytes output,
         final ValidationResult<TransactionValidator.TransactionInvalidReason> validationResult) {
       return new Result(
-          Status.SUCCESSFUL, logs, gasRemaining, output, validationResult, Optional.empty());
+          Status.SUCCESSFUL, logs, gasRefund, output, validationResult, Optional.empty());
     }
 
     Result(
         final Status status,
         final List<Log> logs,
-        final long gasRemaining,
+        final long gasRefund,
         final Bytes output,
         final ValidationResult<TransactionValidator.TransactionInvalidReason> validationResult,
         final Optional<Bytes> revertReason) {
       this.status = status;
       this.logs = logs;
-      this.gasRemaining = gasRemaining;
+      this.gasRefund = gasRefund;
       this.output = output;
       this.validationResult = validationResult;
       this.revertReason = revertReason;
@@ -126,7 +126,7 @@ public class MainnetTransactionProcessor implements TransactionProcessor {
 
     @Override
     public long getGasRefund() {
-      return gasRemaining;
+      return gasRefund;
     }
 
     @Override

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/TransactionProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/TransactionProcessor.java
@@ -64,13 +64,13 @@ public interface TransactionProcessor {
     Status getStatus();
 
     /**
-     * Returns the gas remaining after the transaction was processed.
+     * Returns the gas refund after the transaction was processed.
      *
      * <p>This is only valid when {@code TransactionProcessor#isSuccessful} returns {@code true}.
      *
-     * @return the gas remaining after the transaction was processed
+     * @return the gas refund after the transaction was processed
      */
-    long getGasRemaining();
+    long getGasRefund();
 
     Bytes getOutput();
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivateGroupRehydrationBlockProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivateGroupRehydrationBlockProcessor.java
@@ -166,7 +166,7 @@ public class PrivateGroupRehydrationBlockProcessor {
       }
 
       worldStateUpdater.commit();
-      gasUsed = transaction.getGasLimit() - result.getGasRemaining() + gasUsed;
+      gasUsed = transaction.getGasLimit() - result.getGasRefund() + gasUsed;
       final TransactionReceipt transactionReceipt =
           transactionReceiptFactory.create(result, worldState, gasUsed);
       receipts.add(transactionReceipt);

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivateTransactionProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivateTransactionProcessor.java
@@ -72,7 +72,7 @@ public class PrivateTransactionProcessor {
 
     private final Status status;
 
-    private final long gasRemaining;
+    private final long gasRefund;
 
     private final List<Log> logs;
 
@@ -88,13 +88,13 @@ public class PrivateTransactionProcessor {
     }
 
     public static Result failed(
-        final long gasRemaining,
+        final long gasRefund,
         final ValidationResult<TransactionValidator.TransactionInvalidReason> validationResult,
         final Optional<Bytes> revertReason) {
       return new Result(
           Status.FAILED,
           new ArrayList<>(),
-          gasRemaining,
+          gasRefund,
           Bytes.EMPTY,
           validationResult,
           revertReason);
@@ -102,23 +102,23 @@ public class PrivateTransactionProcessor {
 
     public static Result successful(
         final List<Log> logs,
-        final long gasRemaining,
+        final long gasRefund,
         final Bytes output,
         final ValidationResult<TransactionValidator.TransactionInvalidReason> validationResult) {
       return new Result(
-          Status.SUCCESSFUL, logs, gasRemaining, output, validationResult, Optional.empty());
+          Status.SUCCESSFUL, logs, gasRefund, output, validationResult, Optional.empty());
     }
 
     Result(
         final Status status,
         final List<Log> logs,
-        final long gasRemaining,
+        final long gasRefund,
         final Bytes output,
         final ValidationResult<TransactionValidator.TransactionInvalidReason> validationResult,
         final Optional<Bytes> revertReason) {
       this.status = status;
       this.logs = logs;
-      this.gasRemaining = gasRemaining;
+      this.gasRefund = gasRefund;
       this.output = output;
       this.validationResult = validationResult;
       this.revertReason = revertReason;
@@ -131,7 +131,7 @@ public class PrivateTransactionProcessor {
 
     @Override
     public long getGasRefund() {
-      return gasRemaining;
+      return gasRefund;
     }
 
     @Override

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivateTransactionProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivateTransactionProcessor.java
@@ -130,7 +130,7 @@ public class PrivateTransactionProcessor {
     }
 
     @Override
-    public long getGasRemaining() {
+    public long getGasRefund() {
       return gasRemaining;
     }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/storage/migration/PrivateMigrationBlockProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/storage/migration/PrivateMigrationBlockProcessor.java
@@ -111,7 +111,7 @@ public class PrivateMigrationBlockProcessor {
       }
 
       worldStateUpdater.commit();
-      gasUsed = transaction.getGasLimit() - result.getGasRemaining() + gasUsed;
+      gasUsed = transaction.getGasLimit() - result.getGasRefund() + gasUsed;
       final TransactionReceipt transactionReceipt =
           transactionReceiptFactory.create(result, worldState, gasUsed);
       receipts.add(transactionReceipt);

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulatorResult.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulatorResult.java
@@ -39,7 +39,7 @@ public class TransactionSimulatorResult {
   }
 
   public long getGasEstimate() {
-    return transaction.getGasLimit() - result.getGasRemaining();
+    return transaction.getGasLimit() - result.getGasRefund();
   }
 
   public Bytes getOutput() {

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulatorResultTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulatorResultTest.java
@@ -59,13 +59,13 @@ public class TransactionSimulatorResultTest {
     transactionSimulatorResult.getGasEstimate();
 
     verify(transaction).getGasLimit();
-    verify(result).getGasRemaining();
+    verify(result).getGasRefund();
   }
 
   @Test
   public void shouldCalculateCorrectGasEstimateWhenConsumedAllGas() {
     when(transaction.getGasLimit()).thenReturn(5L);
-    when(result.getGasRemaining()).thenReturn(0L);
+    when(result.getGasRefund()).thenReturn(0L);
 
     assertThat(transactionSimulatorResult.getGasEstimate()).isEqualTo(5L);
   }
@@ -73,7 +73,7 @@ public class TransactionSimulatorResultTest {
   @Test
   public void shouldCalculateCorrectGasEstimateWhenGasWasInsufficient() {
     when(transaction.getGasLimit()).thenReturn(1L);
-    when(result.getGasRemaining()).thenReturn(-5L);
+    when(result.getGasRefund()).thenReturn(-5L);
 
     assertThat(transactionSimulatorResult.getGasEstimate()).isEqualTo(6L);
   }
@@ -81,7 +81,7 @@ public class TransactionSimulatorResultTest {
   @Test
   public void shouldCalculateCorrectGasEstimateWhenGasLimitWasSufficient() {
     when(transaction.getGasLimit()).thenReturn(10L);
-    when(result.getGasRemaining()).thenReturn(3L);
+    when(result.getGasRefund()).thenReturn(3L);
 
     assertThat(transactionSimulatorResult.getGasEstimate()).isEqualTo(7L);
   }


### PR DESCRIPTION
Signed-off-by: Karim TAAM <karim.t2am@gmail.com>

## PR description

Renamed `gasRemaining` to `gasRefund` because that is what is put in it. This will allow to create another gasRemaining variable with the correct value of gasRemaining

https://github.com/matkt/besu/blob/94f8eb69846116d25137b7f555f48ca4a8f986f4/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java#L356