### PR TITLE
EIP1559 Fix testnet issues part2

### DIFF
--- a/consensus/clique/src/main/java/org/hyperledger/besu/consensus/clique/BlockHeaderValidationRulesetFactory.java
+++ b/consensus/clique/src/main/java/org/hyperledger/besu/consensus/clique/BlockHeaderValidationRulesetFactory.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.consensus.clique;
 
+import org.hyperledger.besu.config.experimental.ExperimentalEIPs;
 import org.hyperledger.besu.consensus.clique.headervalidationrules.CliqueDifficultyValidationRule;
 import org.hyperledger.besu.consensus.clique.headervalidationrules.CliqueExtraDataValidationRule;
 import org.hyperledger.besu.consensus.clique.headervalidationrules.CoinbaseHeaderValidationRule;
@@ -22,9 +23,11 @@ import org.hyperledger.besu.consensus.clique.headervalidationrules.VoteValidatio
 import org.hyperledger.besu.consensus.common.EpochManager;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Hash;
+import org.hyperledger.besu.ethereum.core.fees.EIP1559;
 import org.hyperledger.besu.ethereum.mainnet.BlockHeaderValidator;
 import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.AncestryValidationRule;
 import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.ConstantFieldValidationRule;
+import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.EIP1559BlockHeaderGasPriceValidationRule;
 import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.GasLimitRangeAndDeltaValidationRule;
 import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.GasUsageValidationRule;
 import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.TimestampBoundedByFutureParameter;
@@ -60,5 +63,12 @@ public class BlockHeaderValidationRulesetFactory {
         .addRule(new CliqueDifficultyValidationRule())
         .addRule(new SignerRateLimitValidationRule())
         .addRule(new CoinbaseHeaderValidationRule(epochManager));
+  }
+
+  public static BlockHeaderValidator.Builder cliqueEip1559BlockHeaderValidator(
+      final long secondsBetweenBlocks, final EpochManager epochManager, final EIP1559 eip1559) {
+    ExperimentalEIPs.eip1559MustBeEnabled();
+    return cliqueBlockHeaderValidator(secondsBetweenBlocks, epochManager)
+        .addRule((new EIP1559BlockHeaderGasPriceValidationRule(eip1559)));
   }
 }

--- a/consensus/clique/src/main/java/org/hyperledger/besu/consensus/clique/CliqueProtocolSchedule.java
+++ b/consensus/clique/src/main/java/org/hyperledger/besu/consensus/clique/CliqueProtocolSchedule.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.consensus.clique;
 
 import org.hyperledger.besu.config.CliqueConfigOptions;
 import org.hyperledger.besu.config.GenesisConfigOptions;
+import org.hyperledger.besu.config.experimental.ExperimentalEIPs;
 import org.hyperledger.besu.consensus.common.EpochManager;
 import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.MainnetBlockValidator;
@@ -23,6 +24,8 @@ import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.PrivacyParameters;
 import org.hyperledger.besu.ethereum.core.Util;
 import org.hyperledger.besu.ethereum.core.Wei;
+import org.hyperledger.besu.ethereum.core.fees.EIP1559;
+import org.hyperledger.besu.ethereum.mainnet.BlockHeaderValidator;
 import org.hyperledger.besu.ethereum.mainnet.MainnetBlockBodyValidator;
 import org.hyperledger.besu.ethereum.mainnet.MainnetBlockImporter;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
@@ -30,6 +33,7 @@ import org.hyperledger.besu.ethereum.mainnet.ProtocolScheduleBuilder;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpecBuilder;
 
 import java.math.BigInteger;
+import java.util.Optional;
 
 /** Defines the protocol behaviours for a blockchain using Clique. */
 public class CliqueProtocolSchedule {
@@ -51,12 +55,22 @@ public class CliqueProtocolSchedule {
     }
 
     final EpochManager epochManager = new EpochManager(cliqueConfig.getEpochLength());
+
+    final Optional<EIP1559> eip1559 =
+        ExperimentalEIPs.eip1559Enabled
+            ? Optional.of(new EIP1559(config.getEIP1559BlockNumber().orElse(0)))
+            : Optional.empty();
+
     return new ProtocolScheduleBuilder(
             config,
             DEFAULT_CHAIN_ID,
             builder ->
                 applyCliqueSpecificModifications(
-                    epochManager, cliqueConfig.getBlockPeriodSeconds(), localNodeAddress, builder),
+                    epochManager,
+                    cliqueConfig.getBlockPeriodSeconds(),
+                    localNodeAddress,
+                    builder,
+                    eip1559),
             privacyParameters,
             isRevertReasonEnabled)
         .createProtocolSchedule();
@@ -73,14 +87,14 @@ public class CliqueProtocolSchedule {
       final EpochManager epochManager,
       final long secondsBetweenBlocks,
       final Address localNodeAddress,
-      final ProtocolSpecBuilder specBuilder) {
+      final ProtocolSpecBuilder specBuilder,
+      final Optional<EIP1559> eip1559) {
+
     return specBuilder
         .blockHeaderValidatorBuilder(
-            BlockHeaderValidationRulesetFactory.cliqueBlockHeaderValidator(
-                secondsBetweenBlocks, epochManager))
+            getBlockHeaderValidator(epochManager, secondsBetweenBlocks, eip1559))
         .ommerHeaderValidatorBuilder(
-            BlockHeaderValidationRulesetFactory.cliqueBlockHeaderValidator(
-                secondsBetweenBlocks, epochManager))
+            getBlockHeaderValidator(epochManager, secondsBetweenBlocks, eip1559))
         .blockBodyValidatorBuilder(MainnetBlockBodyValidator::new)
         .blockValidatorBuilder(MainnetBlockValidator::new)
         .blockImporterBuilder(MainnetBlockImporter::new)
@@ -89,5 +103,18 @@ public class CliqueProtocolSchedule {
         .skipZeroBlockRewards(true)
         .miningBeneficiaryCalculator(CliqueHelpers::getProposerOfBlock)
         .blockHeaderFunctions(new CliqueBlockHeaderFunctions());
+  }
+
+  private static BlockHeaderValidator.Builder getBlockHeaderValidator(
+      final EpochManager epochManager,
+      final long secondsBetweenBlocks,
+      final Optional<EIP1559> eip1559) {
+    if (ExperimentalEIPs.eip1559Enabled && eip1559.isPresent()) {
+      return BlockHeaderValidationRulesetFactory.cliqueEip1559BlockHeaderValidator(
+          secondsBetweenBlocks, epochManager, eip1559.get());
+    } else {
+      return BlockHeaderValidationRulesetFactory.cliqueBlockHeaderValidator(
+          secondsBetweenBlocks, epochManager);
+    }
   }
 }

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreator.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreator.java
@@ -223,6 +223,7 @@ public abstract class AbstractBlockCreator implements AsyncBlockCreator {
             isCancelled::get,
             miningBeneficiary,
             protocolSpec.getTransactionPriceCalculator(),
+            protocolSpec.getGasBudgetCalculator(),
             protocolSpec.getEip1559());
 
     if (transactions.isPresent()) {

--- a/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/BlockTransactionSelectorTest.java
+++ b/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/BlockTransactionSelectorTest.java
@@ -38,6 +38,7 @@ import org.hyperledger.besu.ethereum.core.TransactionTestFixture;
 import org.hyperledger.besu.ethereum.core.Wei;
 import org.hyperledger.besu.ethereum.core.WorldState;
 import org.hyperledger.besu.ethereum.core.WorldUpdater;
+import org.hyperledger.besu.ethereum.core.fees.TransactionGasBudgetCalculator;
 import org.hyperledger.besu.ethereum.core.fees.TransactionPriceCalculator;
 import org.hyperledger.besu.ethereum.difficulty.fixed.FixedDifficultyProtocolSchedule;
 import org.hyperledger.besu.ethereum.eth.transactions.PendingTransactions;
@@ -122,6 +123,7 @@ public class BlockTransactionSelectorTest {
             this::isCancelled,
             miningBeneficiary,
             TransactionPriceCalculator.frontier(),
+            TransactionGasBudgetCalculator.frontier(),
             Optional.empty());
 
     final BlockTransactionSelector.TransactionSelectionResults results =
@@ -161,6 +163,7 @@ public class BlockTransactionSelectorTest {
             this::isCancelled,
             miningBeneficiary,
             TransactionPriceCalculator.frontier(),
+            TransactionGasBudgetCalculator.frontier(),
             Optional.empty());
 
     final BlockTransactionSelector.TransactionSelectionResults results =
@@ -218,6 +221,7 @@ public class BlockTransactionSelectorTest {
             this::isCancelled,
             miningBeneficiary,
             TransactionPriceCalculator.frontier(),
+            TransactionGasBudgetCalculator.frontier(),
             Optional.empty());
 
     final BlockTransactionSelector.TransactionSelectionResults results =
@@ -262,6 +266,7 @@ public class BlockTransactionSelectorTest {
             this::isCancelled,
             miningBeneficiary,
             TransactionPriceCalculator.frontier(),
+            TransactionGasBudgetCalculator.frontier(),
             Optional.empty());
 
     final BlockTransactionSelector.TransactionSelectionResults results =
@@ -297,6 +302,7 @@ public class BlockTransactionSelectorTest {
             this::isCancelled,
             miningBeneficiary,
             TransactionPriceCalculator.frontier(),
+            TransactionGasBudgetCalculator.frontier(),
             Optional.empty());
 
     final Transaction tx = createTransaction(1);
@@ -333,6 +339,7 @@ public class BlockTransactionSelectorTest {
             this::isCancelled,
             miningBeneficiary,
             TransactionPriceCalculator.frontier(),
+            TransactionGasBudgetCalculator.frontier(),
             Optional.empty());
 
     final TransactionTestFixture txTestFixture = new TransactionTestFixture();
@@ -390,6 +397,7 @@ public class BlockTransactionSelectorTest {
             this::isCancelled,
             miningBeneficiary,
             TransactionPriceCalculator.frontier(),
+            TransactionGasBudgetCalculator.frontier(),
             Optional.empty());
 
     final TransactionTestFixture txTestFixture = new TransactionTestFixture();
@@ -451,6 +459,7 @@ public class BlockTransactionSelectorTest {
             this::isCancelled,
             miningBeneficiary,
             TransactionPriceCalculator.frontier(),
+            TransactionGasBudgetCalculator.frontier(),
             Optional.empty());
 
     final TransactionTestFixture txTestFixture = new TransactionTestFixture();
@@ -534,6 +543,7 @@ public class BlockTransactionSelectorTest {
             this::isCancelled,
             miningBeneficiary,
             TransactionPriceCalculator.frontier(),
+            TransactionGasBudgetCalculator.frontier(),
             Optional.empty());
 
     final BlockTransactionSelector.TransactionSelectionResults results =

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/fees/EIP1559.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/fees/EIP1559.java
@@ -73,12 +73,19 @@ public class EIP1559 {
   }
 
   public long eip1559GasPool(final long blockNumber, final long gasLimit) {
+
     guardActivation();
+    final long eip1559GasTarget;
     if (blockNumber >= finalForkBlknum) {
-      return gasLimit * 2;
+      eip1559GasTarget = gasLimit * 2;
+    } else {
+      eip1559GasTarget =
+          (gasLimit / 2)
+              + (gasLimit / 2)
+                  * (blockNumber - initialForkBlknum)
+                  / feeMarket.getMigrationDurationInBlocks();
     }
-    return ((gasLimit / 2)
-        + ((blockNumber - initialForkBlknum) * feeMarket.getGasIncrementAmount(gasLimit)) * 2);
+    return eip1559GasTarget * 2;
   }
 
   public long legacyGasPool(final long blockNumber, final long gasLimit) {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/fees/FeeMarket.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/fees/FeeMarket.java
@@ -22,10 +22,6 @@ public interface FeeMarket {
 
   long getMigrationDurationInBlocks();
 
-  default long getGasIncrementAmount(final long gasLimit) {
-    return gasLimit / 2 / getMigrationDurationInBlocks();
-  }
-
   long getInitialBasefee();
 
   static FeeMarket eip1559() {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/fees/TransactionGasBudgetCalculator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/fees/TransactionGasBudgetCalculator.java
@@ -14,38 +14,40 @@
  */
 package org.hyperledger.besu.ethereum.core.fees;
 
-import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Transaction;
 
 @FunctionalInterface
 public interface TransactionGasBudgetCalculator {
 
   boolean hasBudget(
-      final Transaction transaction, final BlockHeader blockHeader, final long gasUsed);
+      final Transaction transaction,
+      final long blockNumber,
+      final long gasLimit,
+      final long gasUsed);
 
   static TransactionGasBudgetCalculator frontier() {
-    return gasBudgetCalculator((blockHeader, ignored) -> blockHeader.getGasLimit());
+    return gasBudgetCalculator((blockNumber, gasLimit, ignored) -> gasLimit);
   }
 
   static TransactionGasBudgetCalculator eip1559(final EIP1559 eip1559) {
     return gasBudgetCalculator(
-        (blockHeader, transaction) ->
+        (blockNumber, gasLimit, transaction) ->
             transaction.isEIP1559Transaction()
-                ? eip1559.eip1559GasPool(blockHeader.getNumber(), blockHeader.getGasLimit())
-                : eip1559.legacyGasPool(blockHeader.getNumber(), blockHeader.getGasLimit()));
+                ? eip1559.eip1559GasPool(blockNumber, gasLimit)
+                : eip1559.legacyGasPool(blockNumber, gasLimit));
   }
 
   static TransactionGasBudgetCalculator gasBudgetCalculator(
       final BlockGasLimitCalculator blockGasLimitCalculator) {
-    return (transaction, blockHeader, gasUsed) -> {
+    return (transaction, blockNumber, gasLimit, gasUsed) -> {
       final long remainingGasBudget =
-          blockGasLimitCalculator.apply(blockHeader, transaction) - gasUsed;
+          blockGasLimitCalculator.apply(blockNumber, gasLimit, transaction) - gasUsed;
       return Long.compareUnsigned(transaction.getGasLimit(), remainingGasBudget) <= 0;
     };
   }
 
   @FunctionalInterface
   interface BlockGasLimitCalculator {
-    long apply(BlockHeader blockHeader, Transaction transaction);
+    long apply(final long blockNumber, final long gasLimit, Transaction transaction);
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolSpecs.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolSpecs.java
@@ -357,14 +357,13 @@ public abstract class MainnetProtocolSpecs {
   // TODO EIP-1559 change for the actual fork name when known
   static ProtocolSpecBuilder eip1559Definition(
       final Optional<BigInteger> chainId,
+      final Optional<TransactionPriceCalculator> transactionPriceCalculator,
       final OptionalInt contractSizeLimit,
       final OptionalInt configStackSizeLimit,
       final boolean enableRevertReason,
       final GenesisConfigOptions genesisConfigOptions) {
     ExperimentalEIPs.eip1559MustBeEnabled();
     final int stackSizeLimit = configStackSizeLimit.orElse(MessageFrame.DEFAULT_MAX_STACK_SIZE);
-    final TransactionPriceCalculator transactionPriceCalculator =
-        TransactionPriceCalculator.eip1559();
     final EIP1559 eip1559 = new EIP1559(genesisConfigOptions.getEIP1559BlockNumber().orElse(0));
     return muirGlacierDefinition(
             chainId, contractSizeLimit, configStackSizeLimit, enableRevertReason)
@@ -372,6 +371,7 @@ public abstract class MainnetProtocolSpecs {
             gasCalculator ->
                 new MainnetTransactionValidator(
                     gasCalculator,
+                    transactionPriceCalculator,
                     true,
                     chainId,
                     Optional.of(eip1559),
@@ -389,10 +389,10 @@ public abstract class MainnetProtocolSpecs {
                     true,
                     stackSizeLimit,
                     Account.DEFAULT_VERSION,
-                    transactionPriceCalculator,
+                    transactionPriceCalculator.orElseThrow(),
                     CoinbaseFeePriceCalculator.eip1559()))
         .name("EIP-1559")
-        .transactionPriceCalculator(transactionPriceCalculator)
+        .transactionPriceCalculator(transactionPriceCalculator.orElseThrow())
         .eip1559(Optional.of(eip1559))
         .gasBudgetCalculator(TransactionGasBudgetCalculator.eip1559(eip1559))
         .blockHeaderValidatorBuilder(MainnetBlockHeaderValidator.createEip1559Validator(eip1559))
@@ -403,12 +403,14 @@ public abstract class MainnetProtocolSpecs {
   // TODO EIP-1559 change for the actual fork name when known
   static ProtocolSpecBuilder eip1559FinalizedDefinition(
       final Optional<BigInteger> chainId,
+      final Optional<TransactionPriceCalculator> transactionPriceCalculator,
       final OptionalInt contractSizeLimit,
       final OptionalInt configStackSizeLimit,
       final boolean enableRevertReason,
       final GenesisConfigOptions genesisConfigOptions) {
     return eip1559Definition(
             chainId,
+            transactionPriceCalculator,
             contractSizeLimit,
             configStackSizeLimit,
             enableRevertReason,
@@ -417,6 +419,7 @@ public abstract class MainnetProtocolSpecs {
             gasCalculator ->
                 new MainnetTransactionValidator(
                     gasCalculator,
+                    transactionPriceCalculator,
                     true,
                     chainId,
                     Optional.of(

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
@@ -211,7 +211,7 @@ public class MainnetTransactionProcessor implements TransactionProcessor {
     LOG.trace("Starting execution of {}", transaction);
 
     ValidationResult<TransactionValidator.TransactionInvalidReason> validationResult =
-        transactionValidator.validate(transaction);
+        transactionValidator.validate(transaction, blockHeader.getBaseFee());
     // Make sure the transaction is intrinsically valid before trying to
     // compare against a sender account (because the transaction may not
     // be signed correctly to extract the sender).

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ProtocolScheduleBuilder.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ProtocolScheduleBuilder.java
@@ -18,6 +18,7 @@ import org.hyperledger.besu.config.GenesisConfigOptions;
 import org.hyperledger.besu.config.experimental.ExperimentalEIPs;
 import org.hyperledger.besu.ethereum.core.PrivacyParameters;
 import org.hyperledger.besu.ethereum.core.fees.FeeMarket;
+import org.hyperledger.besu.ethereum.core.fees.TransactionPriceCalculator;
 import org.hyperledger.besu.ethereum.privacy.PrivateTransactionValidator;
 
 import java.math.BigInteger;
@@ -175,11 +176,14 @@ public class ProtocolScheduleBuilder {
     }
 
     if (ExperimentalEIPs.eip1559Enabled) {
+      final Optional<TransactionPriceCalculator> transactionPriceCalculator =
+          Optional.of(TransactionPriceCalculator.eip1559());
       addProtocolSpec(
           protocolSchedule,
           config.getEIP1559BlockNumber(),
           MainnetProtocolSpecs.eip1559Definition(
               chainId,
+              transactionPriceCalculator,
               config.getContractSizeLimit(),
               config.getEvmStackSize(),
               isRevertReasonEnabled,
@@ -194,6 +198,7 @@ public class ProtocolScheduleBuilder {
                   + feeMarket.getMigrationDurationInBlocks()),
           MainnetProtocolSpecs.eip1559FinalizedDefinition(
               chainId,
+              transactionPriceCalculator,
               config.getContractSizeLimit(),
               config.getEvmStackSize(),
               isRevertReasonEnabled,

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/TransactionValidator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/TransactionValidator.java
@@ -18,6 +18,8 @@ import org.hyperledger.besu.ethereum.core.Account;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.core.TransactionFilter;
 
+import java.util.Optional;
+
 /** Validates transaction based on some criteria. */
 public interface TransactionValidator {
 
@@ -29,7 +31,8 @@ public interface TransactionValidator {
    *     Optional} containing a {@link TransactionInvalidReason} that identifies why the transaction
    *     is invalid.
    */
-  ValidationResult<TransactionInvalidReason> validate(Transaction transaction);
+  ValidationResult<TransactionInvalidReason> validate(
+      Transaction transaction, Optional<Long> baseFee);
 
   /**
    * Asserts whether a transaction is valid for the sender accounts current state.

--- a/ethereum/core/src/test-support/java/org/hyperledger/besu/ethereum/core/TransactionTestFixture.java
+++ b/ethereum/core/src/test-support/java/org/hyperledger/besu/ethereum/core/TransactionTestFixture.java
@@ -38,6 +38,9 @@ public class TransactionTestFixture {
 
   private Optional<BigInteger> chainId = Optional.of(BigInteger.valueOf(2018));
 
+  private Optional<Wei> gasPremium = Optional.empty();
+  private Optional<Wei> feeCap = Optional.empty();
+
   public Transaction createTransaction(final KeyPair keys) {
     final Transaction.Builder builder = Transaction.builder();
     builder
@@ -50,6 +53,9 @@ public class TransactionTestFixture {
 
     to.ifPresent(builder::to);
     chainId.ifPresent(builder::chainId);
+
+    gasPremium.ifPresent(builder::gasPremium);
+    feeCap.ifPresent(builder::feeCap);
 
     return builder.signAndBuild(keys);
   }
@@ -91,6 +97,16 @@ public class TransactionTestFixture {
 
   public TransactionTestFixture chainId(final Optional<BigInteger> chainId) {
     this.chainId = chainId;
+    return this;
+  }
+
+  public TransactionTestFixture gasPremium(final Optional<Wei> gasPremium) {
+    this.gasPremium = gasPremium;
+    return this;
+  }
+
+  public TransactionTestFixture feeCap(final Optional<Wei> feeCap) {
+    this.feeCap = feeCap;
     return this;
   }
 }

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/TransactionTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/TransactionTest.java
@@ -23,6 +23,7 @@ import org.hyperledger.besu.ethereum.vm.ReferenceTestProtocolSchedules;
 import org.hyperledger.besu.testutil.JsonTestParameters;
 
 import java.util.Collection;
+import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.Test;
@@ -108,7 +109,7 @@ public class TransactionTest {
 
       // Test transaction deserialization (will throw an exception if it fails).
       final Transaction transaction = Transaction.readFrom(RLP.input(rlp));
-      if (!transactionValidator(milestone).validate(transaction).isValid()) {
+      if (!transactionValidator(milestone).validate(transaction, Optional.empty()).isValid()) {
         throw new RuntimeException(String.format("Transaction is invalid %s", transaction));
       }
 

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/fees/EIP1559Test.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/fees/EIP1559Test.java
@@ -86,20 +86,26 @@ public class EIP1559Test {
 
   @Test
   public void eip1559GasPool() {
-    assertThat(eip1559.eip1559GasPool(FORK_BLOCK + 1, MAX_GAS)).isEqualTo(10000024L);
+    // LEGACY_GAS_LIMIT: BLOCK_GAS_TARGET - EIP1559_GAS_TARGET. The maximum amount of gas legacy
+    // transactions can use in a given block.
+    // EIP1559_GAS_LIMIT: EIP1559_GAS_TARGET * 2. The maximum amount of gas EIP-1559 transactions
+    // can use in a given block.
+    assertThat(eip1559.eip1559GasPool(FORK_BLOCK + 1, MAX_GAS)).isEqualTo(20000024L);
     assertThat(
             eip1559.eip1559GasPool(FORK_BLOCK + 1, MAX_GAS)
                 + eip1559.legacyGasPool(FORK_BLOCK + 1, MAX_GAS))
-        .isEqualTo(25000012L);
+        .isEqualTo((MAX_GAS - 20000024L / 2) + 20000024L);
   }
 
   @Test
   public void legacyGasPool() {
-    assertThat(eip1559.legacyGasPool(FORK_BLOCK + 1, MAX_GAS)).isEqualTo(14999988L);
+    // LEGACY_GAS_LIMIT: BLOCK_GAS_TARGET - EIP1559_GAS_TARGET. The maximum amount of gas legacy
+    // transactions can use in a given block.
+    assertThat(eip1559.legacyGasPool(FORK_BLOCK + 1, MAX_GAS)).isEqualTo(9999988L);
     assertThat(
             eip1559.eip1559GasPool(FORK_BLOCK + 1, MAX_GAS)
                 + eip1559.legacyGasPool(FORK_BLOCK + 1, MAX_GAS))
-        .isEqualTo(25000012L);
+        .isEqualTo(9999988L + (MAX_GAS - 9999988L) * 2);
   }
 
   @Test

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/fees/TransactionGasBudgetCalculatorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/fees/TransactionGasBudgetCalculatorTest.java
@@ -19,7 +19,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.config.experimental.ExperimentalEIPs;
-import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Transaction;
 
 import java.util.Arrays;
@@ -69,15 +68,24 @@ public class TransactionGasBudgetCalculatorTest {
 
   @Parameterized.Parameters
   public static Collection<Object[]> data() {
+    // LEGACY_INITIAL_GAS_LIMIT: BLOCK_GAS_TARGET / 2. The maximum amount of gas that legacy
+    // transactions can use in INITIAL_FORK_BLOCK_NUMBER
+    // EIP1559_INITIAL_GAS_TARGET: BLOCK_GAS_TARGET / 2. The maximum amount of gas that EIP-1559
+    // transactions can use in INITIAL_FORK_BLOCK_NUMBER.
+    // EIP1559_GAS_LIMIT: EIP1559_GAS_TARGET * 2. The maximum amount of gas EIP-1559 transactions
+    // can use in a given block.
     return Arrays.asList(
         new Object[][] {
           {FRONTIER_CALCULATOR, false, 5L, 1L, 10L, 0L, true},
           {FRONTIER_CALCULATOR, false, 11L, 1L, 10L, 0L, false},
           {FRONTIER_CALCULATOR, false, 5L, 1L, 10L, 6L, false},
           {EIP1559_CALCULATOR, false, 5L, EIP_1559_FORK_BLOCK, 10L, 0L, true},
-          {EIP1559_CALCULATOR, false, (MAX_GAS / 2) + 1, 1L, MAX_GAS, 0L, true},
+          {EIP1559_CALCULATOR, false, (MAX_GAS / 2), 1L, MAX_GAS, 0L, true},
+          {EIP1559_CALCULATOR, false, (MAX_GAS / 2) + 1, 1L, MAX_GAS, 0L, false},
           {EIP1559_CALCULATOR, false, (MAX_GAS / 2) - 1, EIP_1559_FORK_BLOCK, 10L, 2L, false},
-          {EIP1559_CALCULATOR, true, (MAX_GAS / 2) + 1, EIP_1559_FORK_BLOCK, MAX_GAS, 0L, false},
+          {EIP1559_CALCULATOR, true, (MAX_GAS / 2) + 1, EIP_1559_FORK_BLOCK, MAX_GAS, 0L, true},
+          {EIP1559_CALCULATOR, true, MAX_GAS + 1, EIP_1559_FORK_BLOCK, MAX_GAS, 0L, false},
+          {EIP1559_CALCULATOR, true, MAX_GAS, EIP_1559_FORK_BLOCK, MAX_GAS, 0L, true},
           {EIP1559_CALCULATOR, true, (MAX_GAS / 2) - 1, EIP_1559_FORK_BLOCK, 10L, 2L, false},
           {
             EIP1559_CALCULATOR,
@@ -113,7 +121,7 @@ public class TransactionGasBudgetCalculatorTest {
             EIP_1559_FORK_BLOCK + 1,
             MAX_GAS,
             0L,
-            true
+            false
           }
         });
   }
@@ -133,16 +141,10 @@ public class TransactionGasBudgetCalculatorTest {
     assertThat(
             gasBudgetCalculator.hasBudget(
                 transaction(isEIP1559, transactionGasLimit),
-                blockHeader(blockNumber, blockHeaderGasLimit),
+                blockNumber,
+                blockHeaderGasLimit,
                 gasUsed))
         .isEqualTo(expectedHasBudget);
-  }
-
-  private BlockHeader blockHeader(final long blockNumber, final long gasLimit) {
-    final BlockHeader blockHeader = mock(BlockHeader.class);
-    when(blockHeader.getNumber()).thenReturn(blockNumber);
-    when(blockHeader.getGasLimit()).thenReturn(gasLimit);
-    return blockHeader;
   }
 
   private Transaction transaction(final boolean isEIP1559, final long gasLimit) {

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/fees/TransactionGasBudgetCalculatorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/fees/TransactionGasBudgetCalculatorTest.java
@@ -90,7 +90,7 @@ public class TransactionGasBudgetCalculatorTest {
           {
             EIP1559_CALCULATOR,
             true,
-            (MAX_GAS / 2) + FEE_MARKET.getGasIncrementAmount(MAX_GAS),
+            (MAX_GAS / 2) + MAX_GAS / 2 / FEE_MARKET.getMigrationDurationInBlocks(),
             EIP_1559_FORK_BLOCK + 1,
             MAX_GAS,
             0L,
@@ -99,7 +99,7 @@ public class TransactionGasBudgetCalculatorTest {
           {
             EIP1559_CALCULATOR,
             true,
-            (MAX_GAS / 2) + FEE_MARKET.getGasIncrementAmount(MAX_GAS) + 1,
+            (MAX_GAS / 2) + MAX_GAS / 2 / FEE_MARKET.getMigrationDurationInBlocks() + 1,
             EIP_1559_FORK_BLOCK + 1,
             MAX_GAS,
             0L,
@@ -108,7 +108,7 @@ public class TransactionGasBudgetCalculatorTest {
           {
             EIP1559_CALCULATOR,
             false,
-            (MAX_GAS / 2) - FEE_MARKET.getGasIncrementAmount(MAX_GAS),
+            (MAX_GAS / 2) - MAX_GAS / 2 / FEE_MARKET.getMigrationDurationInBlocks(),
             EIP_1559_FORK_BLOCK + 1,
             MAX_GAS,
             0L,
@@ -117,7 +117,7 @@ public class TransactionGasBudgetCalculatorTest {
           {
             EIP1559_CALCULATOR,
             false,
-            (MAX_GAS / 2) - FEE_MARKET.getGasIncrementAmount(MAX_GAS) + 1,
+            (MAX_GAS / 2) - MAX_GAS / 2 / FEE_MARKET.getMigrationDurationInBlocks() + 1,
             EIP_1559_FORK_BLOCK + 1,
             MAX_GAS,
             0L,

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessorTest.java
@@ -94,7 +94,7 @@ public class MainnetTransactionProcessorTest {
   private ArgumentCaptor<TransactionValidationParams> transactionValidationParamCaptor() {
     final ArgumentCaptor<TransactionValidationParams> txValidationParamCaptor =
         ArgumentCaptor.forClass(TransactionValidationParams.class);
-    when(transactionValidator.validate(any())).thenReturn(ValidationResult.valid());
+    when(transactionValidator.validate(any(), any())).thenReturn(ValidationResult.valid());
     // returning invalid transaction to halt method execution
     when(transactionValidator.validateForSender(any(), any(), txValidationParamCaptor.capture()))
         .thenReturn(

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionValidatorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionValidatorTest.java
@@ -33,6 +33,7 @@ import org.hyperledger.besu.ethereum.core.TransactionTestFixture;
 import org.hyperledger.besu.ethereum.core.Wei;
 import org.hyperledger.besu.ethereum.core.fees.EIP1559;
 import org.hyperledger.besu.ethereum.core.fees.FeeMarket;
+import org.hyperledger.besu.ethereum.core.fees.TransactionPriceCalculator;
 import org.hyperledger.besu.ethereum.vm.GasCalculator;
 
 import java.math.BigInteger;
@@ -51,6 +52,9 @@ public class MainnetTransactionValidatorTest {
   private static final KeyPair senderKeys = KeyPair.generate();
 
   @Mock private GasCalculator gasCalculator;
+
+  @Mock private TransactionPriceCalculator transactionPriceCalculator;
+
   final FeeMarket feeMarket = FeeMarket.eip1559();
 
   private final Transaction basicTransaction =
@@ -74,7 +78,7 @@ public class MainnetTransactionValidatorTest {
             .createTransaction(senderKeys);
     when(gasCalculator.transactionIntrinsicGasCost(transaction)).thenReturn(Gas.of(50));
 
-    assertThat(validator.validate(transaction))
+    assertThat(validator.validate(transaction, Optional.empty()))
         .isEqualTo(
             ValidationResult.invalid(
                 TransactionValidator.TransactionInvalidReason.INTRINSIC_GAS_EXCEEDS_GAS_LIMIT));
@@ -84,7 +88,7 @@ public class MainnetTransactionValidatorTest {
   public void shouldRejectTransactionWhenTransactionHasChainIdAndValidatorDoesNot() {
     final MainnetTransactionValidator validator =
         new MainnetTransactionValidator(gasCalculator, false, Optional.empty());
-    assertThat(validator.validate(basicTransaction))
+    assertThat(validator.validate(basicTransaction, Optional.empty()))
         .isEqualTo(
             ValidationResult.invalid(
                 TransactionValidator.TransactionInvalidReason
@@ -95,7 +99,7 @@ public class MainnetTransactionValidatorTest {
   public void shouldRejectTransactionWhenTransactionHasIncorrectChainId() {
     final MainnetTransactionValidator validator =
         new MainnetTransactionValidator(gasCalculator, false, Optional.of(BigInteger.valueOf(2)));
-    assertThat(validator.validate(basicTransaction))
+    assertThat(validator.validate(basicTransaction, Optional.empty()))
         .isEqualTo(
             ValidationResult.invalid(TransactionValidator.TransactionInvalidReason.WRONG_CHAIN_ID));
   }
@@ -245,6 +249,7 @@ public class MainnetTransactionValidatorTest {
     final MainnetTransactionValidator validator =
         new MainnetTransactionValidator(
             gasCalculator,
+            Optional.of(transactionPriceCalculator),
             false,
             Optional.empty(),
             Optional.of(eip1559),
@@ -254,7 +259,7 @@ public class MainnetTransactionValidatorTest {
             .gasLimit(21000)
             .chainId(Optional.empty())
             .createTransaction(senderKeys);
-    assertThat(validator.validate(transaction))
+    assertThat(validator.validate(transaction, Optional.empty()))
         .isEqualTo(
             ValidationResult.invalid(
                 TransactionValidator.TransactionInvalidReason.INVALID_TRANSACTION_FORMAT));

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
@@ -251,7 +251,7 @@ public class TransactionPool implements BlockAddedObserver {
       final Transaction transaction) {
     final BlockHeader chainHeadBlockHeader = getChainHeadBlockHeader();
     final ValidationResult<TransactionInvalidReason> basicValidationResult =
-        getTransactionValidator().validate(transaction);
+        getTransactionValidator().validate(transaction, chainHeadBlockHeader.getBaseFee());
     if (!basicValidationResult.isValid()) {
       return basicValidationResult;
     }


### PR DESCRIPTION
Signed-off-by: Karim TAAM <karim.t2am@gmail.com>

# PR description

- Merge PR #1176 
- Update eip1559 Pool and Legacy pool part based on the last version of the EIP (https://eips.ethereum.org/EIPS/eip-1559). 
there was also a problem converting long to int which made the value invalid

````
- EIP1559_INITIAL_GAS_TARGET: BLOCK_GAS_TARGET / 2. The maximum amount of gas that EIP-1559 transactions can use in INITIAL_FORK_BLOCK_NUMBER.
- LEGACY_INITIAL_GAS_LIMIT: BLOCK_GAS_TARGET / 2. The maximum amount of gas that legacy transactions can use in INITIAL_FORK_BLOCK_NUMBER.
- EIP1559_GAS_TARGET: The target gas used by EIP-1559 transactions in a given block.
if CURRENT_BLOCK_NUMBER >= FINAL_FORK_BLOCK_NUMBER then
  BLOCK_GAS_TARGET
elif CURRNT_BLOCK_NUMBER < INITIAL_FORK_BLOCK_NUMBER then
  0
else
  EIP1559_INITIAL_GAS_TARGET + (BLOCK_GAS_TARGET / 2) * (CURRENT_BLOCK_NUMBER - INITIAL_FORK_BLOCK_NUMBER) / MIGRATION_DURATION_IN_BLOCKS
- LEGACY_GAS_LIMIT: BLOCK_GAS_TARGET - EIP1559_GAS_TARGET. The maximum amount of gas legacy transactions can use in a given block.
- EIP1559_GAS_LIMIT: EIP1559_GAS_TARGET * 2. The maximum amount of gas EIP-1559 transactions can use in a given block.
````

This modification allows to fix part of the following issue (illegal block mined) https://github.com/hyperledger/besu/issues/1223

- Update `BlockTransactionSelector` to use the `transactionGasBudgetCalculator` in order to fix the second part of the illegal block mined issue (Transaction processing error: transaction gas limit 21000 exceeds available block budget remaining XXX)

- We had an issue calculating gasUsed at the AbstractBlockProcessor level. We must have a separate counter for eip1559 and Legacy transactions because they have different pools

- Add check to verify that gasPrice is not less than the current BaseFee

- Add missing block header validator for Clique network