### PR TITLE
Set priorities for snapsync

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/GetBytecodeRequest.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/GetBytecodeRequest.java
@@ -47,12 +47,18 @@ public class GetBytecodeRequest extends SnapDataRequest {
   private final GetByteCodesMessage request;
   private GetByteCodesMessage.CodeHashes codeHashes;
   private ByteCodesMessage.ByteCodes response;
+  private final int depth;
+  private final long priority;
 
   protected GetBytecodeRequest(
       final Hash rootHash,
       final ArrayDeque<Bytes32> accountHashes,
-      final ArrayDeque<Bytes32> codeHashes) {
+      final ArrayDeque<Bytes32> codeHashes,
+      final int depth,
+      final long priority) {
     super(BYTECODES, rootHash);
+    this.depth = depth;
+    this.priority = priority;
     LOG.trace(
         "create get bytecode data request for {} accounts with root hash={}",
         accountHashes.size(),
@@ -127,7 +133,7 @@ public class GetBytecodeRequest extends SnapDataRequest {
           new ArrayDeque<>(
               requestData.hashes().stream().skip(lastAccountIndex).collect(Collectors.toList()));
 
-      childRequests.add(createBytecodeRequest(missingAccounts, missingCodes));
+      childRequests.add(createBytecodeRequest(missingAccounts, missingCodes, depth + 1, priority));
     }
 
     return childRequests.stream();
@@ -141,11 +147,11 @@ public class GetBytecodeRequest extends SnapDataRequest {
 
   @Override
   public long getPriority() {
-    return 0;
+    return priority;
   }
 
   @Override
   public int getDepth() {
-    return 0;
+    return depth;
   }
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapDataRequest.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapDataRequest.java
@@ -44,23 +44,39 @@ public abstract class SnapDataRequest implements TasksPriorityProvider {
   }
 
   public static AccountRangeDataRequest createAccountRangeDataRequest(
-      final Hash rootHash, final Bytes32 startKeyHash, final Bytes32 endKeyHash) {
-    return new AccountRangeDataRequest(rootHash, startKeyHash, endKeyHash);
+      final Hash rootHash,
+      final Bytes32 startKeyHash,
+      final Bytes32 endKeyHash,
+      final int depth,
+      final long priority) {
+    return new AccountRangeDataRequest(rootHash, startKeyHash, endKeyHash, depth, priority);
   }
 
   public StorageRangeDataRequest createStorageRangeDataRequest(
       final ArrayDeque<Bytes32> accountsHashes,
       final ArrayDeque<Bytes32> storageRoots,
       final Bytes32 startKeyHash,
-      final Bytes32 endKeyHash) {
+      final Bytes32 endKeyHash,
+      final int depth,
+      final long priority) {
     return new StorageRangeDataRequest(
-        getOriginalRootHash(), accountsHashes, storageRoots, startKeyHash, endKeyHash);
+        getOriginalRootHash(),
+        accountsHashes,
+        storageRoots,
+        startKeyHash,
+        endKeyHash,
+        depth,
+        priority);
   }
 
   public GetBytecodeRequest createBytecodeRequest(
-      final ArrayDeque<Bytes32> accountHashes, final ArrayDeque<Bytes32> codeHashes) {
+      final ArrayDeque<Bytes32> accountHashes,
+      final ArrayDeque<Bytes32> codeHashes,
+      final int depth,
+      final long priority) {
 
-    return new GetBytecodeRequest(getOriginalRootHash(), accountHashes, codeHashes);
+    return new GetBytecodeRequest(
+        getOriginalRootHash(), accountHashes, codeHashes, depth, priority);
   }
 
   public RequestType getRequestType() {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapWorldStateDownloader.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapWorldStateDownloader.java
@@ -32,6 +32,7 @@ import org.hyperledger.besu.services.tasks.InMemoryTasksPriorityQueues;
 import java.time.Clock;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.IntSupplier;
@@ -143,11 +144,13 @@ public class SnapWorldStateDownloader implements WorldStateDownloader {
 
       // snapsync already done, switch to fastsync
       if (fastSyncStateStorage.getFastSyncStep().equals(SyncMode.X_SNAP)) {
+        AtomicLong counter = new AtomicLong(0);
         RangeManager.generateAllRanges(16)
             .forEach(
                 (key, value) ->
                     newDownloadState.enqueueRequest(
-                        SnapDataRequest.createAccountRangeDataRequest(stateRoot, key, value)));
+                        SnapDataRequest.createAccountRangeDataRequest(
+                            stateRoot, key, value, 0, counter.getAndIncrement())));
       } else {
         return healProcess.run(fastSyncActions, fastSyncState);
       }


### PR DESCRIPTION
We assume that:
* new storage requests should be processed before account requests in queue
* new bytecode requests should be processed before existing account requests in queue
* account requests created from unfinished account request should be processed before existing requests already in queue

Signed-off-by: Jiri Peinlich <jiri.peinlich@gmail.com>