### PR TITLE
Refactor BlockAccessListItemSizeCheck interface methods

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/BlockAccessListItemSizeCheck.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/BlockAccessListItemSizeCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright contributors to Hyperledger Besu.
+ * Copyright contributors to Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -24,24 +24,34 @@ public sealed interface BlockAccessListItemSizeCheck
     permits BlockAccessListItemSizeCheck.WithinBudget, BlockAccessListItemSizeCheck.OverBudget {
 
   /** {@code true} when the running item count exceeds the EIP-7928 budget for the header. */
-  default boolean isOverBudget() {
-    return switch (this) {
-      case WithinBudget() -> false;
-      case OverBudget(BlockAccessListValidationError ignored) -> true;
-    };
-  }
+  boolean isOverBudget();
 
   /** Present only when {@link #isOverBudget()} is {@code true}. */
-  default Optional<BlockAccessListValidationError> overBudgetError() {
-    return switch (this) {
-      case WithinBudget() -> Optional.empty();
-      case OverBudget(BlockAccessListValidationError error) -> Optional.of(error);
-    };
+  Optional<BlockAccessListValidationError> overBudgetError();
+
+  record WithinBudget() implements BlockAccessListItemSizeCheck {
+      @Override
+      public boolean isOverBudget() {
+          return false;
+      }
+
+      @Override
+      public Optional<BlockAccessListValidationError> overBudgetError() {
+          return Optional.empty();
+      }
   }
 
-  record WithinBudget() implements BlockAccessListItemSizeCheck {}
+  record OverBudget(BlockAccessListValidationError error) implements BlockAccessListItemSizeCheck {
+      @Override      
+      public boolean isOverBudget() {
+          return true;
+      }
 
-  record OverBudget(BlockAccessListValidationError error) implements BlockAccessListItemSizeCheck {}
+      @Override      
+      public Optional<BlockAccessListValidationError> overBudgetError() {
+          return Optional.of(error);
+      }      
+  }
 
   static WithinBudget withinBudget() {
     return new WithinBudget();


### PR DESCRIPTION
this way the switch is not needed at all

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).